### PR TITLE
feat: add dead link checker and safe auto-fix flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Zero dependencies. Node.js built-in only. Works everywhere Node 20+ runs.
 - Colored terminal output
 - Extended placeholder detection (TODO, FIXME, TBD, WIP, and more)
 - Insecure link detection (inline, bare URLs, reference-style)
+- Optional dead link checker (`--check-links`)
+- Optional safe auto-fix mode (`--fix`, `--dry-run`)
 
 ## Quick Start
 
@@ -29,6 +31,15 @@ npx doclify-guardrail docs/ --strict
 
 # Generate a report
 npx doclify-guardrail docs/ --report
+
+# Check dead links (HTTP status + local relative paths)
+npx doclify-guardrail docs/ --check-links
+
+# Auto-fix safe issues (v1: http:// -> https://)
+npx doclify-guardrail docs/ --fix
+
+# Preview auto-fix without writing files
+npx doclify-guardrail docs/ --fix --dry-run
 ```
 
 ## Usage
@@ -48,6 +59,9 @@ doclify-guardrail --dir <path> [options]
 | `--dir <path>` | Scan all `.md` files in directory (recursive) |
 | `--report [path]` | Generate markdown report (default: `doclify-report.md`) |
 | `--rules <path>` | Load custom rules from JSON file |
+| `--check-links` | Validate links and fail on dead links |
+| `--fix` | Auto-fix safe issues (v1: `http://` to `https://`) |
+| `--dry-run` | Preview `--fix` changes without writing files (only valid with `--fix`) |
 | `--no-color` | Disable colored output |
 | `--debug` | Show runtime details |
 | `-h, --help` | Show help |
@@ -82,6 +96,7 @@ CLI flags override config file values.
 | `line-length` | warning | Lines exceeding max length |
 | `placeholder` | warning | TODO, FIXME, TBD, WIP, HACK, CHANGEME, lorem ipsum, etc. |
 | `insecure-link` | warning | HTTP links (should be HTTPS) |
+| `dead-link` | error | Broken links (enabled with `--check-links`) |
 
 All rules respect code block exclusion -- content inside fenced code blocks
 and inline code is never flagged.
@@ -133,6 +148,22 @@ Pipe JSON output to other tools:
 ```bash
 doclify-guardrail docs/ 2>/dev/null | jq '.summary'
 ```
+
+## Dead Link Checker
+
+Use `--check-links` to validate:
+- `http(s)` links via HTTP status checks
+- relative local file links (e.g. `./guide.md`)
+
+When dead links are found, they are reported as `dead-link` errors.
+
+## Auto-fix (safe v1)
+
+Use `--fix` to automatically upgrade safe `http://` links to `https://`.
+Ambiguous URLs (for example `localhost` or custom ports) are reported and left unchanged.
+
+Use `--dry-run` only together with `--fix` to preview changes without writing files.
+Using `--dry-run` alone is a usage error (exit code `2`).
 
 ## Report
 

--- a/src/checker.mjs
+++ b/src/checker.mjs
@@ -8,7 +8,8 @@ const RULE_SEVERITY = {
   'single-h1': 'error',
   'line-length': 'warning',
   placeholder: 'warning',
-  'insecure-link': 'warning'
+  'insecure-link': 'warning',
+  'dead-link': 'error'
 };
 
 const PLACEHOLDER_PATTERNS = [

--- a/src/fixer.mjs
+++ b/src/fixer.mjs
@@ -1,0 +1,39 @@
+function isAmbiguousHttpUrl(url) {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    const isLocalhost = host === 'localhost' || host === '127.0.0.1' || host === '::1';
+    const hasCustomPort = parsed.port && parsed.port !== '80';
+    return isLocalhost || hasCustomPort;
+  } catch {
+    return true;
+  }
+}
+
+function autoFixInsecureLinks(content) {
+  const changes = [];
+  const ambiguous = [];
+
+  const fixed = content.replace(/http:\/\/\S+/g, (raw) => {
+    const cleaned = raw.replace(/[),.;!?]+$/g, '');
+    if (isAmbiguousHttpUrl(cleaned)) {
+      ambiguous.push(cleaned);
+      return raw;
+    }
+
+    const replaced = raw.replace('http://', 'https://');
+    if (replaced !== raw) {
+      changes.push({ from: raw, to: replaced });
+    }
+    return replaced;
+  });
+
+  return {
+    content: fixed,
+    modified: fixed !== content,
+    changes,
+    ambiguous
+  };
+}
+
+export { autoFixInsecureLinks, isAmbiguousHttpUrl };

--- a/src/links.mjs
+++ b/src/links.mjs
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { stripCodeBlocks, stripInlineCode } from './checker.mjs';
+
+function extractLinks(content) {
+  const stripped = stripCodeBlocks(content);
+  const lines = stripped.split('\n');
+  const links = [];
+
+  for (let idx = 0; idx < lines.length; idx += 1) {
+    const line = stripInlineCode(lines[idx]);
+    const lineNumber = idx + 1;
+
+    const inlineRx = /\[[^\]]*\]\(([^)]+)\)/g;
+    let inline;
+    while ((inline = inlineRx.exec(line)) !== null) {
+      links.push({ url: inline[1].trim(), line: lineNumber, kind: 'inline' });
+    }
+
+    const refDefRx = /^\[[^\]]+\]:\s*(\S+)/;
+    const ref = line.match(refDefRx);
+    if (ref) {
+      links.push({ url: ref[1].trim(), line: lineNumber, kind: 'reference' });
+    }
+
+    const bareRx = /\bhttps?:\/\/\S+/g;
+    let bare;
+    while ((bare = bareRx.exec(line)) !== null) {
+      links.push({ url: bare[0].trim(), line: lineNumber, kind: 'bare' });
+    }
+  }
+
+  // Remove trailing punctuation from bare URL captures
+  return links.map((l) => ({
+    ...l,
+    url: l.url.replace(/[),.;!?]+$/g, '')
+  }));
+}
+
+function isSkippableUrl(url) {
+  return url.startsWith('mailto:') || url.startsWith('tel:') || url.startsWith('#');
+}
+
+async function checkRemoteUrl(url) {
+  try {
+    const headRes = await fetch(url, { method: 'HEAD', redirect: 'follow' });
+    if (headRes.status < 400) {
+      return null;
+    }
+
+    if (headRes.status === 405 || headRes.status === 501) {
+      const getRes = await fetch(url, { method: 'GET', redirect: 'follow' });
+      if (getRes.status < 400) return null;
+      return `HTTP ${getRes.status}`;
+    }
+
+    return `HTTP ${headRes.status}`;
+  } catch (err) {
+    return err.message;
+  }
+}
+
+function checkLocalUrl(url, sourceFile) {
+  const withoutAnchor = url.split('#')[0];
+  if (!withoutAnchor) return null;
+
+  const targetPath = path.resolve(path.dirname(sourceFile), withoutAnchor);
+  return fs.existsSync(targetPath) ? null : 'Target not found';
+}
+
+async function checkDeadLinks(content, { sourceFile }) {
+  const links = extractLinks(content);
+  const findings = [];
+  const seen = new Set();
+
+  for (const link of links) {
+    const url = link.url;
+    if (!url || isSkippableUrl(url)) continue;
+
+    const dedupeKey = `${link.line}:${url}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      const error = await checkRemoteUrl(url);
+      if (error) {
+        findings.push({
+          code: 'dead-link',
+          severity: 'error',
+          line: link.line,
+          message: `Dead link: ${url} (${error})`,
+          source: sourceFile
+        });
+      }
+      continue;
+    }
+
+    if (url.startsWith('/')) {
+      // Absolute filesystem paths are intentionally ignored for portability.
+      continue;
+    }
+
+    const localError = checkLocalUrl(url, sourceFile);
+    if (localError) {
+      findings.push({
+        code: 'dead-link',
+        severity: 'error',
+        line: link.line,
+        message: `Dead link: ${url} (${localError})`,
+        source: sourceFile
+      });
+    }
+  }
+
+  return findings;
+}
+
+export { extractLinks, checkDeadLinks };


### PR DESCRIPTION
## Summary
- add --check-links dead link checker
- add safe auto-fix workflow with --fix and --dry-run
- enforce usage error when --dry-run is used without --fix (exit code 2)
- add test coverage for new flags and behaviors
- update README with new options and examples

## Notes
- Auto-fix v1 intentionally keeps scope minimal/safe: only http:// -> https:// replacements.
- Ambiguous URLs (localhost/custom ports) are reported in JSON output and left unchanged.