### PR TITLE
feat: add doc health score and freshness checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Zero dependencies. Node.js built-in only. Works everywhere Node 20+ runs.
 - Colored terminal output
 - Extended placeholder detection (TODO, FIXME, TBD, WIP, and more)
 - Insecure link detection (inline, bare URLs, reference-style)
+- Doc Health Score per file and project average (0–100)
 - Optional dead link checker (`--check-links`)
+- Optional freshness checker (`--check-freshness`)
 - Optional safe auto-fix mode (`--fix`, `--dry-run`)
 
 ## Quick Start
@@ -34,6 +36,9 @@ npx doclify-guardrail docs/ --report
 
 # Check dead links (HTTP status + local relative paths)
 npx doclify-guardrail docs/ --check-links
+
+# Check document freshness (warn if stale or missing updated date)
+npx doclify-guardrail docs/ --check-freshness
 
 # Auto-fix safe issues (v1: http:// -> https://)
 npx doclify-guardrail docs/ --fix
@@ -60,6 +65,7 @@ doclify-guardrail --dir <path> [options]
 | `--report [path]` | Generate markdown report (default: `doclify-report.md`) |
 | `--rules <path>` | Load custom rules from JSON file |
 | `--check-links` | Validate links and fail on dead links |
+| `--check-freshness` | Warn if docs are stale or missing an updated date (default max age: 180 days) |
 | `--fix` | Auto-fix safe issues (v1: `http://` to `https://`) |
 | `--dry-run` | Preview `--fix` changes without writing files (only valid with `--fix`) |
 | `--no-color` | Disable colored output |
@@ -97,6 +103,7 @@ CLI flags override config file values.
 | `placeholder` | warning | TODO, FIXME, TBD, WIP, HACK, CHANGEME, lorem ipsum, etc. |
 | `insecure-link` | warning | HTTP links (should be HTTPS) |
 | `dead-link` | error | Broken links (enabled with `--check-links`) |
+| `stale-doc` | warning | Missing/old freshness date (enabled with `--check-freshness`) |
 
 All rules respect code block exclusion -- content inside fenced code blocks
 and inline code is never flagged.
@@ -164,6 +171,26 @@ Ambiguous URLs (for example `localhost` or custom ports) are reported and left u
 
 Use `--dry-run` only together with `--fix` to preview changes without writing files.
 Using `--dry-run` alone is a usage error (exit code `2`).
+
+## Doc Health Score
+
+Each file now includes `summary.healthScore` (0–100) in JSON output.
+Overall summary includes `summary.avgHealthScore`.
+
+Scoring is deterministic and compatibility-safe:
+- starts at `100`
+- `-25` per error
+- `-8` per warning
+- clamped to `0..100`
+
+## Doc Freshness
+
+Use `--check-freshness` to detect stale docs.
+The checker looks for dates in:
+- frontmatter keys: `updated`, `last_updated`, `lastModified`, `date`
+- body marker: `Last updated: YYYY-MM-DD`
+
+If no date is found or the doc is older than 180 days, a `stale-doc` warning is added.
 
 ## Report
 

--- a/src/checker.mjs
+++ b/src/checker.mjs
@@ -9,7 +9,8 @@ const RULE_SEVERITY = {
   'line-length': 'warning',
   placeholder: 'warning',
   'insecure-link': 'warning',
-  'dead-link': 'error'
+  'dead-link': 'error',
+  'stale-doc': 'warning'
 };
 
 const PLACEHOLDER_PATTERNS = [

--- a/src/quality.mjs
+++ b/src/quality.mjs
@@ -1,0 +1,94 @@
+import { normalizeFinding } from './checker.mjs';
+
+const DEFAULT_FRESHNESS_DAYS = 180;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function computeDocHealthScore({ errors = 0, warnings = 0 }) {
+  const raw = 100 - (errors * 25) - (warnings * 8);
+  return clamp(Math.round(raw), 0, 100);
+}
+
+function extractFrontmatter(content) {
+  if (!content.startsWith('---\n')) return null;
+  const endIdx = content.indexOf('\n---\n', 4);
+  if (endIdx === -1) return null;
+  return {
+    body: content.slice(4, endIdx),
+    startLine: 2
+  };
+}
+
+function parseIsoDate(value) {
+  if (!value || typeof value !== 'string') return null;
+  const cleaned = value.trim().replace(/^['"]|['"]$/g, '');
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(cleaned)) return null;
+  const date = new Date(`${cleaned}T00:00:00Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function findFreshnessDate(content) {
+  const frontmatter = extractFrontmatter(content);
+  if (frontmatter) {
+    const lines = frontmatter.body.split('\n');
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i];
+      const m = line.match(/^\s*(updated|last_updated|lastModified|date)\s*:\s*(.+)\s*$/i);
+      if (!m) continue;
+      const parsed = parseIsoDate(m[2]);
+      if (parsed) {
+        return {
+          date: parsed,
+          source: m[1],
+          line: frontmatter.startLine + i
+        };
+      }
+    }
+  }
+
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const m = lines[i].match(/last\s*updated\s*:\s*(\d{4}-\d{2}-\d{2})/i);
+    if (!m) continue;
+    const parsed = parseIsoDate(m[1]);
+    if (parsed) {
+      return { date: parsed, source: 'last-updated', line: i + 1 };
+    }
+  }
+
+  return null;
+}
+
+function checkDocFreshness(content, opts = {}) {
+  const sourceFile = opts.sourceFile || undefined;
+  const now = opts.now instanceof Date ? opts.now : new Date();
+  const maxAgeDays = Number.isInteger(opts.maxAgeDays) ? opts.maxAgeDays : DEFAULT_FRESHNESS_DAYS;
+  const findings = [];
+
+  const found = findFreshnessDate(content);
+  if (!found) {
+    findings.push(normalizeFinding(
+      'stale-doc',
+      `No freshness date found. Add frontmatter \`updated: YYYY-MM-DD\` (max ${maxAgeDays} days).`,
+      1,
+      sourceFile
+    ));
+    return findings;
+  }
+
+  const ageDays = Math.floor((now.getTime() - found.date.getTime()) / 86400000);
+  if (ageDays > maxAgeDays) {
+    findings.push(normalizeFinding(
+      'stale-doc',
+      `Document appears stale: ${ageDays} days old (max ${maxAgeDays}).`,
+      found.line,
+      sourceFile
+    ));
+  }
+
+  return findings;
+}
+
+export { computeDocHealthScore, checkDocFreshness, DEFAULT_FRESHNESS_DAYS };

--- a/src/report.mjs
+++ b/src/report.mjs
@@ -17,6 +17,9 @@ function generateReport(output, options) {
   lines.push(`**Date:** ${dateStr}  `);
   lines.push(`**Files scanned:** ${output.summary.filesScanned}  `);
   lines.push(`**Result:** ${output.summary.status === 'PASS' ? '\u2713 PASS' : `\u2717 ${output.summary.totalErrors} errors, ${output.summary.totalWarnings} warnings`}`);
+  if (typeof output.summary.avgHealthScore === 'number') {
+    lines.push(`**Avg health score:** ${output.summary.avgHealthScore}/100`);
+  }
   lines.push('');
 
   // Summary table


### PR DESCRIPTION
## Summary
- adds Doc Health Score (0–100) per file and average project score in JSON output
- adds `--check-freshness` to flag stale docs (or missing update date) as `stale-doc` warnings
- keeps output backward-compatible by only adding new fields

## Implementation
- new module `src/quality.mjs`:
  - `computeDocHealthScore()`
  - `checkDocFreshness()` (frontmatter keys: `updated`, `last_updated`, `lastModified`, `date`; plus `Last updated: YYYY-MM-DD`)
- CLI updates in `src/index.mjs`:
  - parse `--check-freshness`
  - enrich per-file summary with `healthScore`
  - enrich global summary with `avgHealthScore`
  - append freshness warnings when enabled
- report enhancement in `src/report.mjs` to show avg health score when available
- docs updated in `README.md`

## Tests
- added tests for:
  - health score math/clamping
  - `--check-freshness` arg parsing
  - freshness warning behavior
  - JSON output compatibility with new score fields
- full test suite passes (`npm test`)

## Notes
- As requested, this PR does **not** implement timeout/concurrency changes for `--check-links` (kept for next cycle backlog).