### PR TITLE
test: align suite with v1.2 behavior + add regression coverage

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -416,6 +416,7 @@ function buildOutput(fileResults, fileErrors, opts, elapsed, fixSummary) {
   };
 
   summary.healthScore = avgHealthScore;
+  summary.avgHealthScore = avgHealthScore; // Backward-compatible alias for existing integrations/tests
 
   return {
     version: VERSION,


### PR DESCRIPTION
## Summary
- align legacy tests to the new v1.2 behavior (frontmatter opt-in, single-h1 aggregated finding, dynamic CLI version)
- restore backward compatibility for score field by adding `summary.avgHealthScore` alias
- add anti-regression tests for:
  - frontmatter default-off behavior
  - `--version`
  - `--exclude` with simple dir names
  - inline suppressions (`doclify-disable-next-line`, disable/enable block)
  - `--link-allow-list` with `--check-links`

## Validation
- `npm test`
- Result: **80/80 passing**