### PR TITLE
Fase 0: fix sicurezza e bug critici

### DIFF
--- a/specs/fase0/task1_fix-redos-custom-rules.md
+++ b/specs/fase0/task1_fix-redos-custom-rules.md
@@ -1,0 +1,94 @@
+# task 1: Fix ReDoS nelle custom rules
+
+> Fase: 0 | Task: 1 | Effort stimato: S
+
+## Il problema
+
+Oggi `doclify` accetta qualunque regex nelle custom rules e la compila direttamente con `new RegExp()` in [`src/rules-loader.mjs`](/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/src/rules-loader.mjs). Questo e un problema pratico, non teorico: basta una regola come `(a+)+$` e la scansione puo andare in catastrophic backtracking su input sfavorevoli, bloccando la CPU per molto tempo.
+
+Il danno non e solo per chi scrive la regola. Se la rule file finisce in repo e viene usata in CI, l'intera pipeline puo diventare lenta o apparentemente "appesa", con diagnosi difficile. L'utente vede solo che `doclify` non finisce, ma la causa reale e nascosta nella regex.
+
+In questa fase non ci sono task precedenti gia specificate o implementate da ereditare. Quindi il problema residuo e ancora integro: manca un guardrail minimo di sicurezza prima della compilazione.
+
+## La soluzione
+
+Aggiungiamo una validazione preventiva in `rules-loader`: prima di compilare la regex, analizziamo la stringa pattern e rifiutiamo pattern con nested quantifier ad alto rischio (gruppo quantificato che contiene gia quantificatori). Se il pattern e pericoloso, fermiamo subito il caricamento con errore esplicito e actionable.
+
+## Come funziona
+
+Il flusso resta quello attuale: `index` chiama `loadCustomRules()`, che valida ogni regola. La differenza e che `validateCustomRule()` inserisce uno step in piu prima di `new RegExp()`.
+
+Concretamente:
+
+1. `validateCustomRule()` continua a validare `id`, `pattern`, `message`, `severity`.
+2. Prima della compilazione chiama una funzione dedicata, ad esempio `assertRegexIsSafe(rule.pattern, rule.id)`.
+3. La funzione cerca nested quantifier potenzialmente esplosivi, per esempio:
+   - `(a+)+`
+   - `([a-z]+)*`
+   - `(\w*)+`
+4. Se trova un match pericoloso, lancia `Error` con messaggio chiaro:
+   - include `rule.id`
+   - spiega che il pattern e rifiutato per rischio ReDoS
+5. Se il check passa, si procede con `new RegExp(...)` come oggi.
+
+Snippet atteso (firma e intenzione):
+
+```js
+function assertRegexIsSafe(pattern, ruleId) {
+  if (hasNestedQuantifier(pattern)) {
+    throw new Error(`Rule "${ruleId}": unsafe regex pattern (possible ReDoS via nested quantifier)`);
+  }
+}
+```
+
+Lato CLI non serve nuova logica: l'errore viene gia propagato da `loadCustomRules()` e stampato come `Custom rules error: ...` in [`src/index.mjs`](/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/src/index.mjs).
+
+## Decisioni e trade-off
+
+Scelta: validazione euristica locale (zero dependency) in `rules-loader`.
+Perche: il progetto mantiene una filosofia zero-deps nel core CLI; per questo task basta bloccare il caso peggiore richiesto da roadmap senza introdurre parser regex completo.
+Costo: non intercettiamo ogni possibile forma di ReDoS, ma riduciamo il rischio principale subito.
+
+Scelta: fail-fast al caricamento della regola.
+Perche: meglio errore immediato e leggibile rispetto a hang runtime durante scan.
+Costo: alcune regex borderline ma legittime potrebbero essere rifiutate (falso positivo conservativo).
+
+Alternativa scartata: introdurre libreria esterna tipo safe-regex.
+Perche scartata: aumenta superficie dipendenze e complessita manutentiva per un fix che deve essere rapido e mirato.
+Costo della rinuncia: minor completezza analitica rispetto a un parser dedicato.
+
+## File da toccare
+
+[`/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/src/rules-loader.mjs`](/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/src/rules-loader.mjs) - MODIFICA  
+Inserire check di sicurezza regex prima di `new RegExp()`, con helper locale per detection nested quantifier e messaggio errore chiaro.
+
+[`/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/test/guardrail.test.mjs`](/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/test/guardrail.test.mjs) - MODIFICA  
+Aggiungere regression test su `loadCustomRules` (pattern pericoloso rifiutato) e smoke test CLI (`--rules` con pattern pericoloso -> exit 2 + errore esplicito).
+
+## Edge case
+
+Casi gestiti:
+- Pattern chiaramente nested quantifier vengono bloccati prima della compilazione.
+- Pattern malformati restano gestiti dal ramo gia esistente `invalid regex`.
+- Pattern semplici e legittimi (senza nested quantifier) continuano a funzionare invariati.
+
+Casi non gestiti (accettabile in questa task):
+- Tutte le forme non banali di ReDoS non basate su nested quantifier.
+- Analisi semantica completa di escape avanzati, lookaround complessi, backreference pathological.
+
+Il perimetro e coerente con la roadmap: fix mirato e testabile, non motore di analisi regex completo.
+
+## Criteri di done
+
+- Con un `rules.json` contenente `(a+)+$`, `loadCustomRules()` lancia errore che contiene `Rule "..."` e riferimento al rischio ReDoS.
+- Con un pattern sicuro (es. `\\bfoo\\b`) `loadCustomRules()` continua a compilare la regex senza regressioni.
+- CLI con `--rules` puntato a file contenente regex pericolosa termina con exit code `2` e stderr con prefisso `Custom rules error:`.
+- I test gia esistenti su malformed JSON e invalid regex restano verdi.
+
+## Note per chi implementa
+
+Segui il pattern attuale di `rules-loader`: funzioni pure piccole, `throw new Error(...)` con messaggi orientati all'utente, nessun side effect.
+
+Nei test resta coerente con lo stile corrente in [`test/guardrail.test.mjs`](/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/test/guardrail.test.mjs): `node:test`, fixture temporanee con `makeTempDir()`, assert su porzioni di messaggio invece che su stringa intera rigida.
+
+Evita di spostare logica in `index`: il punto giusto e il loader, cosi API programmatica e CLI ricevono la stessa protezione.

--- a/specs/fase0/task2_fix-path-traversal-report.md
+++ b/specs/fase0/task2_fix-path-traversal-report.md
@@ -1,0 +1,97 @@
+# Fix path traversal in report
+
+> Fase: 0 | Task: 2 | Effort stimato: S
+
+## Il problema
+
+Oggi `generateReport()` in `src/report.mjs` prende `--report`, fa `path.resolve()` e scrive subito su disco. Questo significa che un path come `../outside.md` o `/tmp/report.md` viene accettato senza guardrail, anche se esce dal workspace corrente.
+
+Il problema non e teorico. Se Doclify gira in CI o in una macchina condivisa, un input malevolo o sbagliato puo causare scritture fuori progetto, con impatti che vanno da artefatti sporchi a overwrite di file non previsti. Per l’utente il sintomo e invisibile: il comando “funziona”, ma ha scritto dove non doveva.
+
+Nella task precedente abbiamo introdotto un fail-fast di sicurezza nel loader delle custom rules. Il pattern e lo stesso: bloccare input pericolosi vicino al punto d’uso, con errore esplicito. Qui il problema residuo e il path output del report.
+
+## La soluzione
+
+Prima della `writeFileSync`, validiamo che il path finale del report sia dentro `process.cwd()`. Se il candidato esce dal boundary, fermiamo tutto con errore leggibile e non scriviamo nulla.
+
+## Come funziona
+
+Il flusso resta identico fino alla fase finale di `generateReport()`: costruzione markdown, `resolvedPath`, scrittura su disco. Inseriamo un gate tra resolve e write.
+
+Caso concreto: l’utente esegue `doclify docs/ --report ../outside.md` dalla root repo.
+
+1. `index.mjs` passa `args.report` a `generateReport(output, { reportPath })`.
+2. `report.mjs` risolve il path assoluto (`resolvedPath`).
+3. Nuovo check `isDescendantOrSame(resolvedPath, process.cwd())`.
+4. Se `false`, `generateReport()` lancia errore: path non consentito fuori workspace.
+5. `index.mjs` mantiene il comportamento esistente: stampa `Failed to write report: ...` e termina con exit code `2`.
+
+Sotto il cofano servono due helper locali in `report.mjs`:
+
+```js
+function canonicalizeForBoundaryCheck(targetPath) {
+  // realpath del file se esiste; altrimenti realpath della parent + basename
+}
+
+function isDescendantOrSame(candidatePath, basePath) {
+  // confronto via path.relative su path canonici
+}
+```
+
+La canonicalizzazione della parent evita bypass banali via symlink gia esistenti.
+
+## Decisioni e trade-off
+
+Scelta: boundary fisso su `process.cwd()`.
+Perche: e il contratto implicito della CLI oggi (scan/output relativi al cwd) ed e quello richiesto dalla roadmap.
+Costo: non si puo piu scrivere report in path esterni anche per casi legittimi.
+
+Scelta: fail-fast con `throw` dentro `generateReport()`.
+Perche: mantiene la separazione dei ruoli attuale; `index.mjs` resta orchestratore e converte in messaggio utente + exit code.
+Costo: chi usa API interna deve gestire l’eccezione, ma e gia il pattern del modulo.
+
+Scelta: helper locale in `report.mjs` invece di esportare utility da `config-resolver`.
+Perche: riduce coupling fra moduli che hanno responsabilita diverse.
+Costo: piccola duplicazione logica (`isDescendantOrSame`) da tenere allineata.
+
+Alternativa scartata: introdurre una allowlist/flag `--unsafe-report-path`.
+Perche non ora: complica UX e superficie sicurezza in una fase che deve chiudere vulnerabilita note.
+Costo della rinuncia: meno flessibilita per chi vuole output fuori repo.
+
+## File da toccare
+
+- `src/report.mjs` — MODIFICA  
+  Aggiungere validazione di boundary prima della scrittura del report, con helper di canonicalizzazione path + check discendenza.
+
+- `test/guardrail.test.mjs` — MODIFICA  
+  Aggiungere test unit (`generateReport` rifiuta path fuori cwd) e test CLI (`--report ../outside.md` fallisce con exit `2` e messaggio chiaro).
+
+- `tasks/roadmap.md` — MODIFICA  
+  Aggiornare stato task da `todo` a `specified` dopo la scrittura della spec.
+
+## Edge case
+
+Casi gestiti:
+- Path relativo con traversal (`../...`) rifiutato.
+- Path assoluto fuori `cwd` rifiutato.
+- Path dentro `cwd` (anche annidato) accettato.
+- Path con symlink nella parent gia esistente valutato su path canonico.
+
+Casi non gestiti (accettabile ora):
+- Creazione automatica directory mancanti per il report (comportamento invariato).
+- Policy diverse da `cwd` (es. boundary su git root o flag custom).
+
+## Criteri di done
+
+1. `generateReport(output, { reportPath: '../outside.md' })` lancia errore con testo che indica chiaramente il vincolo “inside workspace”.
+2. CLI con `--report ../outside.md` termina con exit code `2` e stampa `Failed to write report: ...`.
+3. CLI con `--report doclify-report.md` continua a scrivere correttamente il report nel progetto.
+4. Non ci sono regressioni nei test esistenti su report (`generateReport` e `--report`).
+
+## Note per chi implementa
+
+Resta coerente con lo stile corrente: helper piccoli nel modulo, `throw new Error(...)` con messaggi user-facing, niente side effect nascosti.
+
+Nei test segui il pattern gia usato in suite: `makeTempDir()`, `spawnSync`, assert su sottostringhe stabili del messaggio invece di matchare l’intera frase.
+
+Non spostare la responsabilita in `index.mjs`: il controllo va in `report.mjs`, cosi copre sia CLI sia uso programmatico.

--- a/specs/fase0/task3_fix-git-argument-injection.md
+++ b/specs/fase0/task3_fix-git-argument-injection.md
@@ -1,0 +1,94 @@
+# Fix git argument injection
+
+> Fase: 0 | Task: 3 | Effort stimato: S
+
+## Il problema
+
+Oggi `src/diff.mjs` valida `base` solo contro metacaratteri shell (`;`, `|`, `&`, ...), ma non blocca i valori che iniziano con `-`. Questo significa che un input pensato come ref Git puo diventare un'opzione di `git diff` invece di un riferimento, alterando il comando eseguito.
+
+Il bug non dipende dalla shell injection classica, perche usiamo `spawnSync` con array argomenti. Il problema e piu sottile: option injection nel comando Git. Se `base` e `--qualcosa`, Git lo interpreta come flag e non come ref, con effetti imprevedibili sul risultato e sulla sicurezza operativa.
+
+Nelle task precedenti di Fase 0 abbiamo gia introdotto guardrail fail-fast su input pericolosi (`rules-loader`, `report`). Qui il residuo e lo stesso pattern: input utente non affidabile accettato troppo a lungo nel flusso.
+
+## La soluzione
+
+Rendere `assertSafeBaseRef()` responsabile anche del vincolo semantico "un ref non puo iniziare con `-`". Se il valore `base` inizia con `-`, il modulo `diff` deve fallire immediatamente con errore esplicito, prima di invocare Git.
+
+## Come funziona
+
+Il flusso attuale resta invariato: `getChangedFiles()` chiama `buildGitArgs()`, che chiama `assertSafeBaseRef()`, poi esegue `spawnSync('git', args)`. Cambia solo la validazione in ingresso.
+
+Caso concreto: un consumer programmatico chiama `getChangedFiles({ base: '--force' })`.
+
+1. `buildGitArgs()` entra nel ramo non staged.
+2. `assertSafeBaseRef('--force')` rileva il prefisso `-`.
+3. Lancia `Error` con messaggio user-facing.
+4. `getChangedFiles()` non invoca Git.
+5. Il chiamante riceve un errore deterministico e tracciabile.
+
+Sotto il cofano la modifica e locale:
+
+```js
+function assertSafeBaseRef(base) {
+  if (typeof base !== 'string' || base.length === 0 || FORBIDDEN_BASE_CHARS_RX.test(base)) {
+    throw new Error('Invalid --base value: contains forbidden shell metacharacters');
+  }
+  if (base.startsWith('-')) {
+    throw new Error('Invalid --base value: must not start with "-"');
+  }
+}
+```
+
+Il check resta centralizzato in `diff.mjs`, cosi copre sia CLI sia uso API interno/esterno senza duplicare logica.
+
+## Decisioni e trade-off
+
+Scelta: bloccare qualsiasi `base` che inizi con `-`.
+Perche: e la guardia minima necessaria per impedire option injection su `git diff` con costo implementativo quasi nullo.
+Costo: eventuali nomi di ref non convenzionali con prefisso `-` verranno rifiutati.
+
+Scelta: mantenere il controllo in `src/diff.mjs` invece che nel parser CLI.
+Perche: il parser CLI gia filtra molti casi, ma non e un confine di sicurezza sufficiente per gli usi programmatici (`getChangedFiles()` chiamato da codice).
+Costo: la validazione viene eseguita anche quando i dati provengono da path gia "fidati" nel layer superiore.
+
+Alternativa scartata: risolvere sempre il ref a commit SHA via comando Git separato (`rev-parse`) e usare solo hash.
+Perche scartata: introduce round-trip aggiuntivo e superficie error handling piu ampia per un bug che la roadmap chiede di chiudere in modo mirato.
+Costo della rinuncia: non otteniamo una normalizzazione completa del ref, solo un guardrail di sicurezza.
+
+## File da toccare
+
+`src/diff.mjs` — MODIFICA  
+Estendere `assertSafeBaseRef()` con il check su prefisso `-` e messaggio errore dedicato.
+
+`test/guardrail.test.mjs` — MODIFICA  
+Aggiungere regression test su `getChangedFiles`/`getChangedMarkdownFiles` con base che inizia con `-`, verificando che l'errore sia lanciato prima di eseguire Git.
+
+`tasks/ROADMAP.md` — MODIFICA  
+Aggiornare lo stato della task corrente da `todo` a `specified`.
+
+## Edge case
+
+Casi gestiti:
+- `base` con metacaratteri shell resta rifiutato come oggi.
+- `base` con prefisso `-` viene rifiutato esplicitamente.
+- `base` valido (`HEAD`, `main`, `origin/main`, hash commit) continua a funzionare invariato.
+
+Casi non gestiti (accettabile ora):
+- Validazione semantica completa dell'esistenza del ref prima del `git diff`.
+- Sanitizzazione di refname complessi oltre al vincolo richiesto dalla task.
+
+## Criteri di done
+
+1. `getChangedFiles({ base: '--force' })` lancia errore con messaggio chiaro su prefisso non valido.
+2. `getChangedMarkdownFiles({ base: '--force' })` propaga lo stesso errore.
+3. Un caso valido (`base: 'HEAD'`) continua a restituire un array senza regressioni.
+4. Il test CLI gia esistente su metacaratteri (`HEAD; ...`) resta verde.
+5. Suite test locale (`node --test test/guardrail.test.mjs`) passa senza nuovi flaky test.
+
+## Note per chi implementa
+
+Mantieni il pattern corrente del progetto: helper piccolo, `throw new Error(...)`, nessuna dipendenza esterna.
+
+Nei test segui lo stile gia presente: fixture isolate con `makeTempDir()`, assert su frammenti stabili del messaggio, niente coupling con output completo di Git.
+
+Non spostare logica in `index.mjs`: il boundary corretto e `diff.mjs`, cosi il guardrail resta valido anche fuori dalla CLI.

--- a/specs/fase0/task4_fix-suppression-map.md
+++ b/specs/fase0/task4_fix-suppression-map.md
@@ -1,0 +1,94 @@
+# task 4: Fix bug suppression map
+
+> Fase: 0 | Task: 4 | Effort stimato: S
+
+## Il problema
+
+Oggi la mappa delle soppressioni inline in [`src/checker.mjs`](/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/src/checker.mjs) ha un comportamento troppo aggressivo quando incontra `<!-- doclify-enable -->` senza lista regole: chiama `activeDisables.clear()` e cancella tutto, non solo il disable globale.
+
+Il bug si vede in un caso reale che un team può scrivere senza malizia: disabilita `placeholder` per tutto il file, apre un blocco temporaneo con `doclify-disable` (globale), poi chiude quel blocco con `doclify-enable`. A quel punto il disable specifico `placeholder` dovrebbe restare attivo, ma viene perso. Il risultato è rumore inatteso nei warning e perdita di fiducia nelle direttive di soppressione.
+
+Nelle task precedenti di fase 0 abbiamo blindato input e output per evitare effetti collaterali invisibili. Qui il problema residuo è simile: una direttiva legittima produce uno stato interno incoerente e quindi un comportamento sorprendente per l’utente.
+
+## La soluzione
+
+Quando `doclify-enable` è usato senza regole, dobbiamo chiudere solo il disable globale (`*`) e lasciare intatti i disable specifici (`rule-id`). In pratica: sostituire la cancellazione completa con una rimozione mirata della chiave `*` nel tracking interno delle soppressioni.
+
+## Come funziona
+
+Il flusso resta quello attuale: `checkMarkdown()` costruisce la suppression map una volta, poi filtra i finding con `isSuppressed()`. Cambia solo la semantica del ramo `doclify-enable` senza argomenti dentro `buildSuppressionMap()`.
+
+Esempio concreto:
+
+```md
+# Title
+<!-- doclify-disable placeholder -->
+TODO A
+<!-- doclify-disable -->
+TODO B
+<!-- doclify-enable -->
+TODO C
+```
+
+Con comportamento corretto, `TODO A`, `TODO B`, `TODO C` restano tutti soppressi per `placeholder`: il blocco globale copre solo la finestra centrale, ma il disable specifico sopravvive anche dopo la sua chiusura.
+
+Sotto il cofano, la logica del ramo di chiusura diventa:
+
+```js
+if (ruleIds === null) {
+  // chiude solo il disable globale
+  activeDisables.delete('*');
+} else {
+  // comportamento invariato: decremento o delete per regole esplicite
+}
+```
+
+Il resto della macchina a stati (`Map` con contatori, supporto a nesting, apply per linea) resta invariato.
+
+## Decisioni e trade-off
+
+Scelta: fix minimale sulla riga incriminata, senza riscrivere `buildSuppressionMap`.
+Perché: il bug è locale e riproducibile; una riscrittura completa alza rischio regressioni su sintassi già coperta da test.
+Costo: manteniamo la complessità attuale della funzione e non semplifichiamo l’architettura in questa task.
+
+Scelta: preservare il modello attuale `Map<ruleId, count>`.
+Perché: il counting supporta nesting e chiusure progressive, già usato dai rami `doclify-disable <rules>` / `doclify-enable <rules>`.
+Costo: il codice resta meno immediato di un modello booleano.
+
+Alternativa scartata: reinterpretare `doclify-enable` senza argomenti come “reset totale”.
+Perché scartata: rompe il contratto descritto dalla roadmap e introduce effetto collaterale su disable specifici già attivi.
+Costo della rinuncia: nessuno pratico; perdiamo solo una semantica più aggressiva che oggi è fonte del bug.
+
+## File da toccare
+
+- `src/checker.mjs` — MODIFICA  
+  Nel ramo `SUPPRESS_BLOCK_END_RX` con `ruleIds === null`, sostituire `activeDisables.clear()` con rimozione mirata del disable globale (`activeDisables.delete('*')`), mantenendo invariata la logica su regole esplicite.
+
+- `test/guardrail.test.mjs` — MODIFICA  
+  Aggiungere un regression test dedicato al caso “disable specifico + disable globale + enable globale” che verifica la persistenza della soppressione specifica dopo la chiusura del blocco globale.
+
+## Edge case
+
+Casi gestiti:
+- nesting tra disable specifici e disable globale;
+- `doclify-enable <rule>` continua a decrementare solo la regola indicata;
+- file con sole direttive globali mantiene comportamento atteso (abilita/disabilita tutto a blocchi).
+
+Casi non gestiti (accettabile ora):
+- validazione sintattica forte di ID regole inesistenti nelle direttive;
+- warning dedicati per direttive sbilanciate o ridondanti.
+
+## Criteri di done
+
+1. Con `<!-- doclify-disable placeholder -->` seguito da blocco `<!-- doclify-disable --> ... <!-- doclify-enable -->`, i finding `placeholder` dopo `doclify-enable` restano soppressi.
+2. Un caso base con solo `<!-- doclify-disable --> ... <!-- doclify-enable -->` continua a riabilitare i finding fuori dal blocco.
+3. I test esistenti di inline suppression in [`test/guardrail.test.mjs`](/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/test/guardrail.test.mjs) restano verdi senza adattamenti non necessari.
+4. Non ci sono cambiamenti nei codici/linee dei finding fuori dal perimetro suppression.
+
+## Note per chi implementa
+
+Segui il pattern corrente del file: mutazioni locali su `Map`, niente nuova dipendenza, niente estrazione prematura di helper se non serve al fix.
+
+Il punto fragile è la semantica di `ruleIds === null`: in quel ramo “all rules” non significa “cancella ogni stato”, significa “operare sulla chiave wildcard”. Mantieni questa distinzione netta anche nei test.
+
+Riusa lo stile test attuale: fixture Markdown inline, filtro per `code === 'placeholder'`, assert su linee per provare che la soppressione persiste nel punto giusto.

--- a/specs/fase0/task5_fix-crash-filesystem.md
+++ b/specs/fase0/task5_fix-crash-filesystem.md
@@ -1,0 +1,97 @@
+# task 5: Fix crash filesystem
+
+> Fase: 0 | Task: 5 | Effort stimato: S
+
+## Il problema
+
+Nel ramo `--fix`, Doclify modifica il contenuto in memoria e poi prova a fare `fs.writeFileSync(...)` direttamente dentro `runScan()` in [`src/index.mjs`](/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/src/index.mjs). Se il filesystem rifiuta la scrittura (permessi, path sparito, disco pieno, mount read-only), oggi il dettaglio utente dipende da un errore grezzo di sistema.
+
+Il punto dolente e che l'utente non sta facendo una operazione "esotica": sta usando una feature core (`--fix`). Quando fallisce in scrittura, quello che serve non e un codice errno crudo ma un messaggio che dica chiaramente quale file non e stato scritto e che il problema e I/O, non parsing markdown.
+
+Nelle task precedenti di Fase 0 abbiamo chiuso vulnerabilita da input non fidato e comportamenti sorprendenti (`rules-loader`, `report`, `diff`, suppression map). Qui il residuo e di robustezza operativa: il comando non deve sembrare "rotto" quando fallisce una write, deve fallire in modo leggibile.
+
+## La soluzione
+
+Introduciamo un boundary di errore locale attorno alla write dei fix: intercettiamo il fallimento di `writeFileSync`, lo traduciamo in errore user-facing con path del file e causa, e lasciamo invariato il flusso generale che raccoglie `fileErrors` senza crash globale.
+
+## Come funziona
+
+Il flusso rimane quello esistente: Doclify legge il file, applica fix link/formattazione, poi decide se scrivere. La differenza e nel punto di write: invece di chiamare direttamente `fs.writeFileSync`, incapsuliamo il blocco in `try/catch` e rilanciamo un errore normalizzato.
+
+Scenario concreto: `doclify docs/ --fix` su un file reso read-only tra read e write.
+
+1. `runScan()` calcola `fixed` e/o `formatted` come oggi.
+2. Entra nel ramo `!args.dryRun && (fixed.modified || formatted.modified)`.
+3. Prova la write in `try`.
+4. Se fallisce, costruisce un errore esplicito tipo:
+   `Unable to write fixed file "<relative-or-absolute-path>": EACCES: permission denied`
+5. Il `catch` esterno per-file di `runScan()` continua a convertire questo errore in `fileErrors[]`, quindi niente stack trace, niente crash dell'intera run.
+
+Snippet atteso:
+
+```js
+if (!args.dryRun && (fixed.modified || formatted.modified)) {
+  try {
+    fs.writeFileSync(filePath, content, 'utf8');
+    recordSelfWrite(opts.watchState, filePath);
+  } catch (err) {
+    const reason = err && err.message ? err.message : String(err);
+    throw new Error(`Unable to write fixed file "${toRelativePath(filePath)}": ${reason}`);
+  }
+}
+```
+
+Il punto importante e la semantica: non nascondiamo la causa originale, la rendiamo leggibile e contestualizzata.
+
+## Decisioni e trade-off
+
+Scelta: `try/catch` locale nel ramo write di `runScan()`, non un handler globale.
+Perche: l'errore va contestualizzato con il file specifico nel momento in cui avviene. Un wrapper globale perde precisione e rischia messaggi ambigui.
+Costo: piccola duplicazione di pattern rispetto ad altri writer (`report`, `junit`, `sarif`, `badge`) che hanno gia un proprio catch.
+
+Scelta: rilanciare `Error` con prefisso user-facing e dettaglio originale.
+Perche: il prefisso rende chiaro il dominio ("fixed file write"), il dettaglio conserva diagnostica utile.
+Costo: il messaggio finale contiene una parte dipendente dalla piattaforma (`EACCES`, `EROFS`, etc.), quindi i test devono assertare su frammenti stabili.
+
+Alternativa scartata: intercettare errore e fare solo log warning continuando la run come se nulla fosse.
+Perche scartata: sarebbe fuorviante; l'utente chiedeva `--fix`, quindi una write fallita deve restare un fallimento verificabile.
+Costo della rinuncia: niente "best effort silent mode", ma comportamento piu corretto per CI.
+
+## File da toccare
+
+- `/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/src/index.mjs` - MODIFICA  
+  Inserire `try/catch` locale attorno a `fs.writeFileSync` nel ramo `--fix` e rilanciare errore contestualizzato con path file.
+
+- `/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/test/guardrail.test.mjs` - MODIFICA  
+  Aggiungere test CLI che simula file non scrivibile durante `--fix` e verifica: nessun crash, exit non-zero, messaggio `fileErrors` chiaro con prefisso nuovo.
+
+- `/Users/lorenzoborgato/Dev/doclify-guardrail-mvp/tasks/roadmap.md` - MODIFICA  
+  Aggiornare stato della task da `todo` a `specified` dopo la creazione della spec.
+
+## Edge case
+
+Casi gestiti:
+- file diventato read-only tra lettura e scrittura;
+- path eliminato/spostato tra lettura e scrittura;
+- errore I/O generico senza `message` standard (fallback su `String(err)`).
+
+Casi non gestiti (accettabile ora):
+- retry automatico su errori transitori;
+- classificazione fine per errno con suggerimenti diversi per ogni OS;
+- rollback di fix applicati ad altri file gia scritti in precedenza nella stessa run.
+
+## Criteri di done
+
+1. Eseguendo `doclify <file> --fix` su un file non scrivibile, il processo non termina con stack trace non gestito.
+2. L'output JSON contiene `fileErrors` con errore che include prefisso `Unable to write fixed file`.
+3. Il messaggio errore include il path del file target e conserva il motivo originale del sistema (es. `EACCES`/`EROFS`/`ENOENT`).
+4. Un caso nominale `--fix` su file scrivibile continua a funzionare senza regressioni.
+5. I test preesistenti relativi a `--fix`, `--dry-run` e report restano verdi.
+
+## Note per chi implementa
+
+Seguire il pattern gia usato nel progetto: errori user-facing sintetici, nessuna nuova dipendenza, e assert test su substring stabili invece che su messaggio completo.
+
+Mantenere `recordSelfWrite(...)` nello stesso blocco `try` dopo la write riuscita: se la write fallisce non deve essere registrata come self-write in watch mode.
+
+Non spostare logica in moduli nuovi: il fix e locale a `runScan()` e deve restare li per coerenza con il flusso attuale.

--- a/src/checker.mjs
+++ b/src/checker.mjs
@@ -308,7 +308,7 @@ function buildSuppressionMap(lines) {
     if (blockEndMatch) {
       const ruleIds = parseRuleIds(blockEndMatch[1]);
       if (ruleIds === null) {
-        activeDisables.clear();
+        activeDisables.delete('*');
       } else {
         for (const id of ruleIds) {
           const count = activeDisables.get(id) || 0;

--- a/src/diff.mjs
+++ b/src/diff.mjs
@@ -8,6 +8,9 @@ function assertSafeBaseRef(base) {
   if (typeof base !== 'string' || base.length === 0 || FORBIDDEN_BASE_CHARS_RX.test(base)) {
     throw new Error('Invalid --base value: contains forbidden shell metacharacters');
   }
+  if (base.startsWith('-')) {
+    throw new Error('Invalid --base value: must not start with "-"');
+  }
 }
 
 function buildGitArgs(base = 'HEAD', staged = false) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1394,8 +1394,13 @@ async function runScan(args, resolved, filePaths, customRules, opts = {}) {
         }
 
         if (!args.dryRun && (fixed.modified || formatted.modified)) {
-          fs.writeFileSync(filePath, content, 'utf8');
-          recordSelfWrite(opts.watchState, filePath);
+          try {
+            fs.writeFileSync(filePath, content, 'utf8');
+            recordSelfWrite(opts.watchState, filePath);
+          } catch (err) {
+            const reason = err && err.message ? err.message : String(err);
+            throw new Error(`Unable to write fixed file "${toRelativePath(filePath)}": ${reason}`);
+          }
         }
       }
 

--- a/src/report.mjs
+++ b/src/report.mjs
@@ -1,6 +1,32 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+function canonicalizeForBoundaryCheck(targetPath) {
+  const resolved = path.resolve(targetPath);
+  if (fs.existsSync(resolved)) {
+    try {
+      return fs.realpathSync(resolved);
+    } catch {
+      return resolved;
+    }
+  }
+
+  const parentDir = path.dirname(resolved);
+  try {
+    const canonicalParent = fs.realpathSync(parentDir);
+    return path.join(canonicalParent, path.basename(resolved));
+  } catch {
+    return resolved;
+  }
+}
+
+function isDescendantOrSame(candidatePath, basePath) {
+  const resolvedCandidate = canonicalizeForBoundaryCheck(candidatePath);
+  const resolvedBase = canonicalizeForBoundaryCheck(basePath);
+  const rel = path.relative(resolvedBase, resolvedCandidate);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
 /**
  * Generate a markdown report from scan results and write it to disk.
  * @param {object} output - full output object with files[], summary
@@ -108,6 +134,9 @@ function generateReport(output, options) {
 
   const reportContent = lines.join('\n');
   const resolvedPath = path.resolve(options.reportPath);
+  if (!isDescendantOrSame(resolvedPath, process.cwd())) {
+    throw new Error(`Report path must be inside workspace: ${resolvedPath}`);
+  }
   fs.writeFileSync(resolvedPath, reportContent, 'utf8');
   return resolvedPath;
 }

--- a/src/rules-loader.mjs
+++ b/src/rules-loader.mjs
@@ -1,6 +1,134 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+function parseRegexQuantifier(pattern, startIndex) {
+  const ch = pattern[startIndex];
+  const maybeLazy = pattern[startIndex + 1] === '?';
+
+  if (ch === '*' || ch === '+' || ch === '?') {
+    if (ch === '+') {
+      return { min: 1, max: Infinity, length: maybeLazy ? 2 : 1 };
+    }
+    if (ch === '*') {
+      return { min: 0, max: Infinity, length: maybeLazy ? 2 : 1 };
+    }
+    return { min: 0, max: 1, length: maybeLazy ? 2 : 1 };
+  }
+
+  if (ch !== '{') return null;
+
+  let idx = startIndex + 1;
+  if (idx >= pattern.length || !/\d/.test(pattern[idx])) return null;
+
+  while (idx < pattern.length && /\d/.test(pattern[idx])) idx += 1;
+  const min = Number(pattern.slice(startIndex + 1, idx));
+
+  let max = min;
+  if (pattern[idx] === ',') {
+    idx += 1;
+    const maxStart = idx;
+    while (idx < pattern.length && /\d/.test(pattern[idx])) idx += 1;
+    const maxPart = pattern.slice(maxStart, idx);
+    max = maxPart === '' ? Infinity : Number(maxPart);
+  }
+
+  if (pattern[idx] !== '}') return null;
+  idx += 1;
+
+  if (pattern[idx] === '?') idx += 1;
+
+  return {
+    min,
+    max,
+    length: idx - startIndex
+  };
+}
+
+function allowsMultipleRepeats(quantifier) {
+  return quantifier.max === Infinity || quantifier.max > 1;
+}
+
+function isVariableLengthQuantifier(quantifier) {
+  return quantifier.max === Infinity || quantifier.min !== quantifier.max;
+}
+
+function hasNestedQuantifierRisk(pattern) {
+  const groups = [{ hasVariableQuantifier: false }];
+  let inCharClass = false;
+  let lastToken = null;
+
+  for (let i = 0; i < pattern.length; i += 1) {
+    const ch = pattern[i];
+
+    if (ch === '\\') {
+      i += 1;
+      lastToken = { type: 'atom' };
+      continue;
+    }
+
+    if (inCharClass) {
+      if (ch === ']') inCharClass = false;
+      continue;
+    }
+
+    if (ch === '[') {
+      inCharClass = true;
+      lastToken = { type: 'atom' };
+      continue;
+    }
+
+    if (ch === '(') {
+      groups.push({ hasVariableQuantifier: false });
+      lastToken = null;
+      continue;
+    }
+
+    if (ch === ')') {
+      if (groups.length <= 1) {
+        lastToken = { type: 'atom' };
+        continue;
+      }
+
+      const closedGroup = groups.pop();
+      groups[groups.length - 1].hasVariableQuantifier ||= closedGroup.hasVariableQuantifier;
+      lastToken = {
+        type: 'group',
+        hasVariableQuantifier: closedGroup.hasVariableQuantifier
+      };
+      continue;
+    }
+
+    const quantifier = parseRegexQuantifier(pattern, i);
+    if (quantifier) {
+      if (
+        lastToken?.type === 'group'
+        && lastToken.hasVariableQuantifier
+        && allowsMultipleRepeats(quantifier)
+      ) {
+        return true;
+      }
+
+      if (isVariableLengthQuantifier(quantifier)) {
+        groups[groups.length - 1].hasVariableQuantifier = true;
+      }
+
+      i += quantifier.length - 1;
+      lastToken = { type: 'quantifier' };
+      continue;
+    }
+
+    lastToken = { type: 'atom' };
+  }
+
+  return false;
+}
+
+function assertRegexIsSafe(pattern, ruleId) {
+  if (hasNestedQuantifierRisk(pattern)) {
+    throw new Error(`Rule "${ruleId}": unsafe regex pattern (possible ReDoS via nested quantifier)`);
+  }
+}
+
 /**
  * Load and validate custom rules from a JSON file.
  * @param {string} rulesPath - path to JSON rules file
@@ -42,6 +170,8 @@ function validateCustomRule(rule, index) {
   if (severity !== 'error' && severity !== 'warning') {
     throw new Error(`Rule "${rule.id}": severity must be "error" or "warning"`);
   }
+
+  assertRegexIsSafe(rule.pattern, rule.id);
 
   let compiledRegex;
   try {

--- a/tasks/roadmap.md
+++ b/tasks/roadmap.md
@@ -1,346 +1,113 @@
-# Doclify Painpoint-Driven Implementation Roadmap
+# Doclify Guardrail — Roadmap
 
-This document is an execution artifact, not a vision memo. It is grounded in the repository state verified on March 11, 2026, and it is optimized for one ICP first: open-source maintainers who own docs quality in active repositories, with a delivery team of 3-5 engineers.
+> v1.7.2 | Aggiornata: 2026-03-14
 
-## Current Product Reality
+---
 
-Doclify is technically stronger than its public footprint suggests, but its external signals do not yet earn market trust. The local workspace is at `1.7.1` (`package.json`), npm is at `1.7.0`, and GitHub latest release is still `v1.6.0` (published 2026-03-06). This release-channel split is not cosmetic: maintainers treat release coherence as a reliability proxy before they add anything to CI.
+## Fase 0 — Sicurezza e bug fix (priorita: critica) (status: done)
 
-The core is real software, not a toy script. `src/index.mjs` is a 1,927-line orchestrator with scan, diff/staged, watch, fix, trend, reports, GitHub-facing outputs, auth, and cloud AI commands. `src/checker.mjs` is a 986-line regex-first engine with 35 built-in rules and inline suppression controls. Rule execution is deliberately split: core static checks run in `checker.mjs`, then opt-in post-passes run for dead links (`src/links.mjs`), freshness (`src/quality.mjs`), and drift (`src/drift.mjs`). The score formula is explicit and deterministic: `score = clamp(round(100 - errors*20 - (5*sqrt(warnings) + warnings*2)), 0, 100)`.
+Prima di tutto fixare le vulnerabilita e i bug. Ogni task e indipendente: fix, test, commit. Una alla volta.
 
-Reliability discipline is better than what most early-stage CLIs ship. The test suite passes at `235/235`. There is a corpus runner, deterministic and network baselines, waiver expiry policy, and threshold files (`bench/`, `scripts/run-corpus.mjs`, `docs/reliability-gate.md`). There is even a doc-sync guardrail (`scripts/check-docs-sync.mjs`) that prevents README/docs drift on rule count and action references.
+- **task 1: Fix ReDoS nelle custom rules** (status: done) — `src/rules-loader.mjs:48` accetta qualsiasi regex senza validazione. Pattern tipo `(a+)+$` bloccano Node per sempre. Aggiungi validazione che rifiuti nested quantifier prima di `new RegExp()`. Test: pattern pericoloso → errore chiaro.
 
-Now the hard truth: distribution is weak and lags product quality. Doclify currently sits at 1 GitHub star and about 240 npm downloads/week. In the same week range, markdownlint is about 1.77M downloads/week, remark-lint about 324k, textlint about 105k, alex about 38k, markdown-it above 20M. This is not a quality gap only; it is an ecosystem and trust gap. Competitors own editor pathways, pre-commit pathways, and plugin pathways. Doclify currently owns none of these as a first-class surface.
+- **task 2: Fix path traversal in report** (status: done) — `src/report.mjs:110` scrive dove gli dici senza controllo. Con `--report ../../etc/passwd` scrivi fuori dal progetto. Dopo `path.resolve()`, verifica che il risultato sia dentro `process.cwd()` con `isDescendantOrSame()`. Test: path `../outside` → rifiutato.
 
-Market signals are consistent across the required comparator set. markdownlint wins on distribution surface (CLI variants, action, editor integrations). remark-lint and textlint win on AST/plugin maturity and long-tail ecosystem breadth. Vale wins on prose intelligence positioning and broad editor/platform integration while keeping an OSS CLI core. alex has a narrower scope but still owns a clear inclusive-language niche, with long-running issue pressure around internationalization. markdown-it dominates as parser infrastructure with an enormous plugin ecosystem, not as a docs quality gate. lychee owns the specialized link-checking niche, with issue traffic concentrated on path/base-url UX, fragment handling, and high-volume performance/caching behavior. Also, "zero dependency" is true for the CLI package surface, but not for the full product envelope: the GitHub Action is a separate Node package with `@actions/core` and `@actions/github`. This is fine technically, but messaging must stop collapsing CLI constraints and distribution constraints into the same claim.
+- **task 3: Fix git argument injection** (status: done) — `src/diff.mjs:7-10` non blocca ref che iniziano con `-`. Un `--exec=malicious` passa il check. Aggiungi `if (ref.startsWith('-')) throw`. Test: `--force` come base ref → rifiutato.
 
-## Painpoint Map
+- **task 4: Fix bug suppression map** (status: done) — `src/checker.mjs:310`, `<!-- doclify-enable -->` senza regole chiama `activeDisables.clear()` che cancella TUTTO, anche le soppressioni specifiche per regola. Cambia in `activeDisables.delete('*')`. Test: `<!-- doclify-disable rule-a -->` + `<!-- doclify-enable -->` → `rule-a` resta disabilitata.
 
-### 1) False-positive trust
+- **task 5: Fix crash filesystem** (status: done) — `src/index.mjs:1397`, `writeFileSync` senza try/catch. Disco pieno o path inesistente = stack trace brutto. Wrappa in try/catch con messaggio leggibile. Test: path non scrivibile → errore user-friendly.
 
-User Pain: maintainers stop using a linter after two or three incorrect high-friction findings, because review time is scarcer than tooling time.
+**Risultato**: zero vulnerabilita note, test suite verde.
 
-Code/System Cause: the rule engine is regex-heavy and line-oriented; advanced intent rules (`duplicate-section-intent`, anchor heuristics, link title consistency) are useful but can drift on edge Markdown dialects and mixed-content docs. The project has no public false-positive taxonomy yet.
+---
 
-Business Impact: one false positive in CI has a direct cost, but repeated false positives create silent churn and uninstall.
+## Fase 1 — Pulizia e credibilita (priorita: alta) (status: todo)
 
-Why It Blocks Growth: trust is a prerequisite for distribution. If maintainers do not trust findings, they do not wire the tool into pre-commit or required checks, so network effects never start.
+Rimuovere tutto cio che e rotto, incompleto, o danneggia la percezione del prodotto. Niente feature nuove qui — solo sistemare quello che c'e.
 
-### 2) Setup friction
+- **task 1: Nascondi comandi `ai *` placeholder** — `src/index.mjs`: i comandi `ai scan`, `ai fix`, `ai prioritize`, `ai coverage` sono stub vuoti visibili nella help. Danneggiano la credibilita. Spostali dietro flag `--experimental`: senza flag non appaiono nella help e rispondono "Feature in sviluppo, usa --experimental". Test: `doclify --help` senza `--experimental` → nessun comando `ai` visibile.
 
-User Pain: initial setup asks users to choose from many flags and semantics (`strict`, `min-score`, link/freshness/drift, multiple outputs, config chain) before they have seen first value.
+- **task 2: Rendi `duplicate-section-intent` opt-in** — `src/checker.mjs`: questa regola genera troppi falsi positivi con heading simili ma legittimi. Cambiala da attiva di default a opt-in (attiva solo se abilitata nel config). Test: scan senza config esplicito → nessun warning `duplicate-section-intent`.
 
-Code/System Cause: `index.mjs` exposes a broad surface fast, but no opinionated setup profiles tied to maintainer jobs.
+- **task 3: Allinea release channels** — npm e GitHub devono mostrare la stessa versione. Pubblica su npm e crea GitHub release con tag v1.7.2. Verifica: `npm view doclify-guardrail version` = 1.7.2, `gh release view v1.7.2` esiste.
 
-Business Impact: time-to-first-value stays high; trial users do one run and leave.
+- **task 4: Fix link checker hang** — `src/links.mjs:177`: DNS lookup senza timeout, se il DNS non risponde il processo si blocca per sempre. Wrappa con `Promise.race([lookup(...), timeout(5000)])`. Anche: `src/links.mjs:390`, cache DNS e HTTP crescono senza limite → cap a 2048 entry con eviction FIFO. Test: mock DNS che non risponde → timeout dopo 5s, non hang infinito.
 
-Why It Blocks Growth: tools that win in OSS maintainer workflows typically offer one obvious path to "safe default in CI in 10 minutes."
+**Risultato**: il prodotto e pulito, coerente, senza roba rotta visibile. Chi lo installa per la prima volta vede un tool professionale.
 
-### 3) Weak local feedback loop
+---
 
-User Pain: maintainers need actionable feedback before pushing, not only in CI logs.
+## Fase 2 — Distribuzione e onboarding (priorita: alta) (status: todo)
 
-Code/System Cause: watch mode exists, but there is no official editor integration and no maintained pre-commit package owned by Doclify. Incremental cache semantics for routine local re-runs are not a first-class contract yet.
+Il problema di Doclify non e tecnico — e che nessuno lo trova e chi lo trova ci mette troppo a configurarlo. markdownlint ha 1.5M download/settimana perche ha VS Code extension, pre-commit hook, e setup immediato. Questa fase colma quei gap.
+Lavora in sequenza: prima `init` (fondamento), poi pre-commit e VS Code.
 
-Business Impact: low rerun frequency locally, high late-cycle CI failures, and slower habit formation.
+- **task 1: Comando `doclify init`** — Nuovo comando interattivo in `src/index.mjs`: (1) chiede tipo progetto (docs-only, monorepo, MDX), (2) genera `.doclify-guardrail.json` con preset, (3) genera `.github/workflows/doclify.yml`, (4) esegue prima scan. Obiettivo: da `npm install` a CI verde in <10 minuti. Test: `doclify init --preset default` in directory vuota con un .md → config + workflow creati, scan passa.
 
-Why It Blocks Growth: without local loop ownership, adoption depends on policy enforcement, not developer pull.
+- **task 2: Config presets** — `src/config-resolver.mjs`: tre preset — `default` (regole base, no link check), `strict` (tutto attivo), `minimal` (solo errori). Usabili con `--preset` o `"preset"` nel config. Il preset applica opzioni predefinite prima dei CLI override. Test: `--preset strict` attiva `--check-links` e `--check-freshness` automaticamente.
 
-### 4) Lack of extensibility
+- **task 3: Pre-commit hook** — Crea `.pre-commit-hooks.yaml` nella root: entry che esegue `doclify scan --diff --staged`. Documenta nel README le 3 righe YAML da copiare. Test: in un repo di test, modifica .md con errore → pre-commit blocca il commit.
 
-User Pain: teams need custom policy beyond built-ins, but regex-only JSON custom rules are not enough for structural or AST-aware checks.
+- **task 4: VS Code extension MVP** — Nuovo repo `vscode-doclify`. L'estensione: (1) esegue `doclify scan --json` sul file aperto, (2) mostra finding come diagnostics inline (sottolineature), (3) offre quick-fix per le 13 regole auto-fixable. Test: file .md con `#heading` (senza spazio) → warning inline, quick-fix lo corregge.
 
-Code/System Cause: custom rules are loaded from static regex definitions (`src/rules-loader.mjs`) with no plugin runtime contract, no lifecycle hooks, and no stable semver story for third-party rule authors.
+- **task 5: Output PR migliorato** — `src/ci-output.mjs` e `action/`: il commento PR e troppo verboso. Cambialo: (1) delta score vs commit precedente ("+3 punti"), (2) errori in cima, (3) warning a basso impatto collassati. Test: 2 errori + 15 warning → errori visibili, warning collassati.
 
-Business Impact: advanced teams migrate to ecosystems with plugin contracts (remark/textlint) once requirements evolve.
+**Risultato**: un developer fa `npx doclify-guardrail init`, ha CI in 5 minuti, vede finding in VS Code, pre-commit blocca commit con errori. Target: >1000 npm download/settimana.
 
-Why It Blocks Growth: no extensibility means Doclify can only win in narrow policy domains, and narrow domains do not compound adoption.
+---
 
-### 5) No clear editor/pre-commit ownership
+## Fase 3 — AI Layer MVP (priorita: media) (status: todo)
 
-User Pain: maintainers need one canonical "how we run this in PR and local hooks" package that is maintained by the same project.
+Punto di svolta: da tool gratuito a prodotto monetizzabile. Nessun competitor linting Markdown offre AI in CI. Lo spazio e completamente vuoto.
+Prima il backend, poi le feature AI una alla volta. Ogni feature deve funzionare end-to-end prima di passare alla successiva.
 
-Code/System Cause: README has examples, but no official `pre-commit` hook repo, no language-server bridge, and no editor extension path.
+- **task 1: Backend API serverless** — Nuovo repo `doclify-api`, deploy su Cloudflare Workers. Endpoint: `POST /v1/auth/verify`, `POST /v1/ai/review` (proxy Claude API), `POST /v1/ai/fix`, `GET /v1/usage`. Rate limit: 60 req/min per API key. Test: `/v1/ai/review` con API key valida e body Markdown → ritorna finding AI.
 
-Business Impact: fragmented setup quality, higher support burden, lower repeatability across repos.
+- **task 2: `doclify ai review`** — Nuovo `src/ai-review.mjs`. Legge file Markdown, invia al backend che li passa a Claude Haiku 4.5 con prompt strutturato (chiarezza, completezza, tono, accuratezza). Output integrato con finding statici ma etichettato `[AI]`. Costo ~$0.002/file. Test: file con sezione incompleta → finding AI segnala il problema.
 
-Why It Blocks Growth: distribution channels are products, not docs snippets.
+- **task 3: `doclify ai fix`** — Nuovo `src/ai-fix.mjs`. Per ogni finding, invia finding + 10 righe di contesto a Claude Sonnet 4.6 via `/v1/ai/fix`. Ritorna sezione riscritta, utente vede diff e decide. Costo ~$0.02/file. Test: heading con punteggiatura → suggerimento AI corretto + diff leggibile.
 
-### 6) Weak release/public trust signals
+- **task 4: `doclify ai explain-drift`** — In `src/drift.mjs`, flag `--ai-explain`: invia risultati drift a Claude Haiku con prompt "spiega cosa potrebbe essere stale e cosa aggiornare". Costo ~$0.002/alert. Test: drift alert simulato → spiegazione in linguaggio naturale.
 
-User Pain: users cannot quickly infer what version is safe and current.
+- **task 5: Free tier** — Backend: ogni API key ha 50 file AI review/mese gratis. Dopo il limite: "Hai raggiunto il limite. Esegui `doclify upgrade`." Reset il primo del mese. Test: 51esima chiamata → errore 429 con messaggio chiaro.
 
-Code/System Cause: local tags include `v1.7.0` and `v1.7.1`, npm has `1.7.0`, GitHub release stream stops at `v1.6.0`.
+**Risultato**: `doclify ai review` funziona end-to-end. Free tier attivo. Almeno 100 utenti provano l'AI review.
 
-Business Impact: friction for enterprise and cautious OSS maintainers; slower CI pinning.
+---
 
-Why It Blocks Growth: trust decay at install time reduces adoption before technical evaluation starts.
+## Fase 4 — Monetizzazione (priorita: media) (status: todo)
 
-### 7) Unclear paid value boundary
+Trasforma le feature AI in revenue. Boundary non negoziabile: linting statico gratis per sempre, solo AI cloud a pagamento.
+Prima billing, poi pricing page, poi CLI upgrade flow.
 
-User Pain: users need to understand what stays free forever and what value is worth paying for.
+- **task 1: Stripe integration** — Backend: Stripe Billing con due piani — Pro ($19/repo/mese, 2000 file AI), Team ($49/org/mese, 5 repo, quota condivisa). Webhook per attivazione automatica. Test: subscription di test → API key promossa a "pro", quota = 2000.
 
-Code/System Cause: AI command namespace exists, but major paid-intent commands are still placeholders (`ai fix`, `ai prioritize`, `ai coverage`), and packaging is not explicit yet.
+- **task 2: Pricing page** — Landing page statica (GitHub Pages o doclify.dev). Tre colonne: Free / Pro / Team. Chiaro in 5 secondi cosa e gratis. Link a Stripe Checkout. Test: click "Inizia con Pro" → Stripe Checkout → API key attivata in 30s.
 
-Business Impact: no conversion path, only speculative interest.
+- **task 3: CLI upgrade e quota** — `src/index.mjs`: (1) `doclify usage` mostra quota rimasta, (2) `doclify upgrade` apre browser su pricing, (3) quota esaurita → messaggio chiaro con link upgrade. Test: 50/50 file usati + `doclify ai review` → messaggio quota esaurita.
 
-Why It Blocks Growth: unclear boundary creates both OSS skepticism and low buyer urgency.
+- **task 4: Boundary enforcement** — `src/index.mjs` e `src/cloud-client.mjs`: `scan`, `fix`, `diff`, `watch`, `trend`, `report` funzionano SEMPRE senza auth. Comandi `ai *` richiedono auth + quota. Linting statico non rallenta se il cloud e giu. Test: `scan` senza auth → funziona. `ai review` senza auth → "Esegui `doclify login`".
 
-## Phase 0 (0-4 weeks): Trust and Product Integrity
+**Risultato**: primo utente pagante. Billing automatico. Boundary free/paid chiaro. Target MRR: >$500.
 
-### Painpoint
+---
 
-Release incoherence and false-positive trust debt are blocking adoption before feature depth is even evaluated.
+## Fase 5 — Moat e crescita (priorita: bassa) (status: todo)
 
-### Implementation Streams
+Cose che i competitor non possono copiare in meno di 6 mesi. Il vantaggio a questo punto e: scoring + drift + AI in CI — combinazione unica. Questa fase lo rende difendibile.
+Task piu grandi, alcune parallelizzabili.
 
-Stream A is release synchronization policy and automation: every shipped version must publish coherently to tag, GitHub release, npm, and action tag within 24 hours, with a single release manifest artifact. Stream B is reliability signal publication: publish deterministic/nightly benchmark report cards from `bench/out` in every release note. Stream C is finder-level false-positive triage: classify each false-positive issue by rule, dialect, and repro pattern, then ship weekly precision patches against the top two noisy rules. Stream D is CLI surface simplification planning: introduce profile-driven presets (`maintainer-safe`, `strict-ci`, `link-heavy`) while preserving current flags as compatibility aliases.
+- **task 1: Plugin JS v1** — Nuovi `src/plugin-loader.mjs` e `src/plugin-api.mjs`. Un plugin e un file `.mjs` che esporta `{ id, severity, check(context) }`. Loader con timeout 5s. Custom rules regex restano come adapter. Template repo `doclify-plugin-template`. Test: plugin "heading maiuscolo" → Doclify lo carica e lo esegue.
 
-### Effort
+- **task 2: Repository memory** — Backend: `POST /v1/memory` salva score per commit, finding accettati/rifiutati, drift history. CLI invia dati opt-in dopo scan. AI review usa la memory: "Questo fix accettato 8/10 volte". Test: 5 scan → `/v1/memory` ritorna storia completa.
 
-About 18-22 engineer-weeks. Most work is tooling, release pipeline hardening, and triage instrumentation, not deep parser work.
+- **task 3: Scan incrementale** — Nuovo `src/cache.mjs`. SHA256 per file, salta file non modificati, cache in `.doclify-cache.json`. Se config cambia → invalida tutto. Target: >35% piu veloce su repo >50 file. Test: scan due volte senza modifiche → seconda >35% piu veloce, risultato identico.
 
-### Dependencies
+- **task 4: AST parsing opzionale** — `src/checker.mjs`, flag `--ast`. Usa `mdast-util-from-markdown`. Migra 3 regole: `heading-hierarchy`, `no-empty-sections`, `broken-local-anchor`. Mantieni path regex per chi non vuole la dep. Test: scan con/senza `--ast` → risultati identici per le 3 regole.
 
-No external dependencies are required; this phase depends on internal release ownership and issue labeling discipline.
+- **task 5: Style guide packs** — Pack per Google e Microsoft style guide. File JSON di custom rules o plugin. Pacchetti npm separati (`doclify-style-google`, `doclify-style-microsoft`). Test: pack Google installato → regole Google applicate.
 
-### Technical Risk
+- **task 6: Benchmark pubblico** — Script `scripts/run-benchmark.mjs` su corpus in `bench/`. Report trimestrale: precision, recall, performance, confronto con markdownlint e Vale. Test: script genera report con tutte le metriche.
 
-Low to medium. The main risk is underestimating triage throughput for noisy rule categories.
-
-### Adoption KPI
-
-Release coherence reaches 100% for all new versions (local tag = npm = GitHub release within 24 hours). First-pass success rate for new repos (scan completes with understandable, actionable output in first run) reaches at least 75%. False-positive-labeled issue share drops by at least 40% from the baseline measured in week 1.
-
-### Conversion KPI
-
-At least 8% of weekly active repositories opt into cloud-auth setup (`login` or token-based run) even before paid activation, proving trust in cloud path readiness.
-
-### Gating Criteria
-
-Phase 1 only starts when release coherence is stable for two consecutive releases and false-positive issue share is trending down for three consecutive weeks.
-
-### Phase 0 Task Backlog and Definition of Done
-
-| Task | Work | Definition of Done |
-|---|---|---|
-| P0-T1 Release Sync Pipeline | Build a single release pipeline that checks and publishes version coherence across git tag, npm package, GitHub release, and Action tag. | A release job fails on any version mismatch and produces one signed release manifest artifact; two consecutive releases pass with full coherence. |
-| P0-T2 Release Channel Reconciliation | Align lagging public channels to current shipped state, including missing release artifacts and release notes. | `v1.7.0` and `v1.7.1` are visible and complete on GitHub releases, npm and docs reference the same current stable version, and release checklist is automated. |
-| P0-T3 Reliability Signal Publication | Turn `bench/out` outputs into release-facing reliability reports with deterministic and network trend summaries. | Each release note includes benchmark snapshot links and pass/fail thresholds; report generation is CI-driven and reproducible from one command. |
-| P0-T4 False-Positive Triage Loop | Add issue template labels and taxonomy (`rule_id`, `dialect`, `repro`, `severity`) and weekly triage cadence. | 95% of new trust issues are triaged within 72 hours and linked to a reproducible fixture or an explicit “not reproducible” outcome. |
-| P0-T5 Precision Rule Hardening | Patch the two noisiest rules weekly based on triage data and add regression fixtures. | False-positive issue share drops at least 40% from baseline and each patched rule has at least one new failing-then-passing fixture in test suite. |
-| P0-T6 CLI Profile Plan | Define profile-based onboarding (`maintainer-safe`, `strict-ci`, `link-heavy`) with compatibility mapping to existing flags. | Profile spec is published, CLI compatibility tests pass with old flags unchanged, and one experimental profile can run end-to-end behind a feature flag. |
-
-## Phase 1 (weeks 4-10): OSS Maintainer Adoption Loop
-
-### Painpoint
-
-Doclify is not yet embedded in the maintainer daily loop (pre-commit, review, rerun).
-
-### Implementation Streams
-
-Stream A is pre-commit-first distribution: ship and maintain an official pre-commit hook package and a one-command bootstrap for common docs repos. Stream B is reviewer-friendly outputs: default PR output should collapse noise and surface file-level score deltas, highest-risk findings, and direct fix suggestions; SARIF/JUnit stay machine-facing. Stream C is incremental local loop: implement content-hash cache and changed-file short-circuit for standard scan runs, with explicit invalidation rules. Stream D is templates for maintainer workflows: publish ready-to-apply templates for docs-only repos, mixed monorepos, and MDX-heavy sites.
-
-### Effort
-
-About 24-30 engineer-weeks, mostly in CLI UX, cache mechanics, and distribution packaging.
-
-### Dependencies
-
-Phase 0 trust signals must be stable. Template work depends on real sample repositories and feedback loops.
-
-### Technical Risk
-
-Medium. Cache invalidation mistakes can produce stale results and erode trust if contract semantics are not explicit.
-
-### Adoption KPI
-
-Median time-to-first-value drops below 10 minutes from install to first green CI run. Weekly active repositories reach 1,500. Local rerun frequency reaches at least 2.2 runs per active repository per week.
-
-### Conversion KPI
-
-At least 12% of active repositories enable one cloud-adjacent workflow (auth plus drift mode usage), creating a qualified pipeline for paid conversion in Phase 3.
-
-### Gating Criteria
-
-Phase 2 starts only when weekly active repositories sustain above 1,500 for four consecutive weeks and cache correctness regression rate is below 0.5%.
-
-### Phase 1 Task Backlog and Definition of Done
-
-| Task | Work | Definition of Done |
-|---|---|---|
-| P1-T1 Official Pre-commit Distribution | Ship and maintain an official pre-commit integration package owned by Doclify with versioned docs and examples. | Maintainers can enable Doclify in pre-commit with one copy-paste snippet; integration tests validate staged-file behavior across Linux/macOS. |
-| P1-T2 Maintainer Bootstrap Command | Add guided setup command for docs repos (config, CI template, recommended defaults). | A new repo reaches first successful CI run in under 10 minutes median in internal dogfooding trials. |
-| P1-T3 Reviewer-Friendly Output Mode | Introduce review-focused output showing file score deltas, high-risk findings first, and direct fix pointers. | PR comment/action output is reduced in noise by measured line count while preserving all blocking findings; maintainer usability score improves in feedback survey. |
-| P1-T4 Incremental Cache Engine | Implement content-hash cache and changed-file short-circuit for local reruns with explicit invalidation rules. | Cache hit/miss metrics are exposed in JSON output, correctness regression stays below 0.5%, and rerun wall time improves by at least 35% on benchmark repos. |
-| P1-T5 Workflow Templates | Publish templates for docs-only, monorepo, and MDX-heavy setups with tested CI snippets. | Three template paths are documented and verified by CI smoke tests on reference repositories. |
-| P1-T6 Adoption Telemetry Baseline | Instrument time-to-first-value, weekly active repos, and rerun frequency without collecting content payloads. | KPI dashboards update daily, include data-quality checks, and support phase gate decisions without manual spreadsheet work. |
-
-## Phase 2 (weeks 10-18): Extensibility That Actually Scales
-
-### Painpoint
-
-Regex-only customization caps product depth and pushes advanced teams to other ecosystems.
-
-### Implementation Streams
-
-Stream A is plugin interface v1 design: stable runtime hooks, metadata, severity contracts, and deterministic execution order. Stream B is AST-backed execution path introduction: keep regex path for speed and compatibility, but add parser-backed rule contexts for structure-aware checks and MDX-safe behavior. Stream C is versioned rule/runtime contracts: semver policy for plugin API, rule capabilities, and deprecation windows. Stream D is migration bridge: existing JSON regex rules continue to run, but can be wrapped as plugin adapters to avoid ecosystem breakage.
-
-### Effort
-
-About 34-42 engineer-weeks, because this phase touches architecture, compatibility, and long-term ecosystem contracts.
-
-### Dependencies
-
-Requires stable cache semantics and output schema discipline from Phase 1, plus robust fixture coverage for MD/MDX variants.
-
-### Technical Risk
-
-High. Parser selection and AST abstraction mistakes can overcomplicate the core or degrade performance if not constrained.
-
-### Adoption KPI
-
-At least 20 externally maintained plugin/rule packs published or migrated to plugin API v1, with at least 25% of active repositories using one custom plugin.
-
-### Conversion KPI
-
-Cloud conversion-qualified repositories (repos with plugin usage plus drift usage) reach 400, proving that advanced workflows correlate with willingness to pay.
-
-### Gating Criteria
-
-Phase 3 starts only when plugin API v1 is documented, compatibility tests cover old regex rules, and performance budget regression stays under 15% on deterministic corpus p95.
-
-### Phase 2 Task Backlog and Definition of Done
-
-| Task | Work | Definition of Done |
-|---|---|---|
-| P2-T1 Plugin API v1 Spec | Define plugin lifecycle hooks, rule metadata schema, severity contract, and deterministic execution order. | API spec is versioned, published, and accompanied by a reference plugin and contract tests. |
-| P2-T2 Plugin Runtime Loader | Build runtime loader with isolation guards (timeouts, controlled capabilities, deterministic ordering). | Loader runs reference plugins deterministically, enforces timeout limits, and surfaces machine-readable plugin failure reasons. |
-| P2-T3 AST Execution Path | Introduce parser-backed rule context while preserving current regex path for compatibility and speed. | At least three built-in rules run on AST path behind feature flag with parity tests and p95 performance regression under 15%. |
-| P2-T4 Legacy Rule Adapter | Provide adapter to run current JSON regex custom rules through plugin runtime without breaking users. | Existing custom rule files execute unchanged in compatibility mode and migration warnings are explicit and suppressible. |
-| P2-T5 Contract Versioning Policy | Define semver and deprecation windows for plugin runtime, output schema, and rule capability flags. | Version policy is documented, enforced in CI checks, and every breaking change proposal requires migration notes. |
-| P2-T6 Ecosystem Starter Kits | Publish plugin author templates, fixtures, and CI recipes to reduce third-party onboarding friction. | At least five external maintainers publish compatible plugins using starter kit within phase window. |
-
-## Phase 3 (weeks 18-26): Paid Conversion Layer
-
-### Painpoint
-
-Without a hard free-vs-paid boundary, pricing feels arbitrary and adoption trust collapses.
-
-### Implementation Streams
-
-Stream A is strict boundary enforcement: OSS core remains free forever for scan/fix/rules/output/CI surfaces; paid scope is cloud intelligence only. Stream B is paid intelligence features: repository memory over time, guided fix workflows ranked by acceptance likelihood, and drift prioritization tied to historical breakage patterns. Stream C is packaging and billing: maintainer plan per repo/month with included run quota and transparent overage; team plan per organization with shared quotas, policy controls, and audit trails. Stream D is conversion telemetry: instrument the OSS-to-paid funnel at workflow boundaries, not marketing events.
-
-### Effort
-
-About 30-38 engineer-weeks across cloud APIs, billing integration, workflow UX, and governance controls.
-
-### Dependencies
-
-Needs plugin/runtime contracts from Phase 2 and durable auth/session model already present in the CLI.
-
-### Technical Risk
-
-Medium to high. The biggest risk is building paid features that feel like optional dashboards instead of daily maintainer leverage.
-
-### Adoption KPI
-
-Cloud-active repositories reach 2,000, with weekly guided-fix workflow usage above 30% among cloud-active maintainers.
-
-### Conversion KPI
-
-Paid conversion reaches 6-9% of cloud-active repositories within 90 days. Target pricing starts at approximately EUR 24/repo/month for maintainers (2,500 cloud runs included, then usage overage) and EUR 129/org/month entry for teams with pooled quotas.
-
-### Gating Criteria
-
-Phase 4 starts only if paid churn at day 90 stays below 5% and at least 35% of paid users accept one guided fix recommendation per month.
-
-### Phase 3 Task Backlog and Definition of Done
-
-| Task | Work | Definition of Done |
-|---|---|---|
-| P3-T1 Free vs Paid Boundary Enforcement | Encode and document immutable boundary: OSS local guardrails free, cloud intelligence paid. | Pricing page, README, and CLI help are consistent; no free feature is silently moved to paid scope without a published migration policy. |
-| P3-T2 Repository Memory Service | Implement cloud-backed repository memory (accepted fixes, drift history, policy memory) with export support. | Memory APIs are live, export endpoint works, and data retention/security controls are documented and tested. |
-| P3-T3 Guided Fix Workflow | Build ranked fix recommendations tied to prior acceptance patterns and maintainer review flow. | Users can request prioritized fix plans, apply recommendations, and acceptance telemetry is captured end-to-end. |
-| P3-T4 Drift Prioritization Intelligence | Add cloud ranking model that prioritizes likely-doc-drift findings by impact and confidence. | Cloud drift output shows ranked rationale with confidence, and high-risk precision beats offline baseline on validation set. |
-| P3-T5 Billing, Quotas, and Metering | Implement per-repo and per-org packaging, included run quotas, overage metering, and billing events. | Plans can be subscribed, usage is metered correctly in reconciliation tests, quota exhaustion behavior is explicit and non-destructive. |
-| P3-T6 Conversion Funnel Instrumentation | Track OSS-to-cloud-to-paid journey through product events, not marketing-only events. | Funnel dashboard exposes activation, trial-to-paid, and 90-day retention with cohort views used in weekly reviews. |
-
-## Phase 4 (6-12 months): Distribution and Defensible Moat
-
-### Painpoint
-
-The product can work, but without channel ownership and data compounding it remains replaceable.
-
-### Implementation Streams
-
-Stream A is editor and review integrations: first-party VS Code extension, pre-commit package maturity, and Git provider native review annotations. Stream B is CI ecosystem breadth: maintained integrations for GitHub, GitLab, and lightweight wrappers for common monorepo task runners. Stream C is evidence-based benchmark publication: recurring public benchmark reports against representative docs corpora with explicit false-positive precision and performance metrics. Stream D is community rule-pack ecosystem: certified rule packs, compatibility badges, and strict plugin quality gates.
-
-### Effort
-
-About 42-56 engineer-weeks, mostly integration and ecosystem maintenance work.
-
-### Dependencies
-
-Depends on stable plugin API, cloud intelligence maturity, and reliable release operations.
-
-### Technical Risk
-
-Medium. Integration sprawl can consume capacity if certification and compatibility policy are not strict.
-
-### Adoption KPI
-
-Weekly active repositories exceed 8,000, with at least 40% running Doclify in both local and CI contexts.
-
-### Conversion KPI
-
-Paid penetration reaches 10-14% of cloud-active repositories, with expansion revenue driven by multi-repo team plans rather than one-off seats.
-
-### Gating Criteria
-
-This phase is considered successful only if growth is compounding without support-ticket explosion: support load per 1,000 active repos must fall quarter over quarter.
-
-### Phase 4 Task Backlog and Definition of Done
-
-| Task | Work | Definition of Done |
-|---|---|---|
-| P4-T1 VS Code Integration | Build first-party VS Code extension with diagnostics, quick-fix entry points, and profile-aware configuration. | Extension is published, supports inline diagnostics from Doclify runs, and reaches stable adoption with crash/error budget under target. |
-| P4-T2 CI Ecosystem Expansion | Ship maintained integrations for GitHub and GitLab plus wrappers for common monorepo runners. | Integration guides are tested in CI matrix and installation success rate exceeds 90% in onboarding telemetry. |
-| P4-T3 Public Benchmark Program | Publish recurring benchmark reports comparing precision, performance, and stability on representative corpora. | Quarterly benchmark reports are public, reproducible from tagged datasets, and include methodology and raw artifacts. |
-| P4-T4 Rule-Pack Certification Program | Create compatibility/certification pipeline for community rule packs and quality badges. | Certification CI is live, badge criteria are public, and at least ten community packs are certified without manual exceptions. |
-| P4-T5 Moat Data Layer | Operationalize repository memory plus accepted-fix history plus drift intelligence as compounding product substrate. | Retrieval APIs power both OSS-adjacent and paid workflows, and recommendation quality improves with longitudinal usage data. |
-| P4-T6 Support Scalability System | Build support triage automation, issue taxonomy, and self-serve diagnostics for integrations/plugins. | Support load per 1,000 active repos declines quarter-over-quarter while satisfaction scores remain stable or improve. |
-
-## Monetization Design
-
-The boundary must be explicit and boring: static linting, scoring, fixing, reporting, and CI outputs remain open-source and free. Paid value starts only where historical intelligence matters: repository memory evolution, guided fixes ranked by prior acceptance, and drift prioritization informed by change history. The lock-in strategy is not file hostage tactics. It is workflow intelligence accumulated over time and reused every week.
-
-Conversion path is straightforward: teams adopt free CLI in CI, enable cloud auth for drift insights, then hit usage moments where historical guidance saves review hours. At that point, paying is cheaper than continued manual triage.
-
-To keep prioritization honest, backlog ordering must combine user pain, adoption leverage, and conversion leverage under engineering cost:
-
-```text
-priority_score = ((pain_severity * affected_repos) + (adoption_lift * 2) + (conversion_lift * 3) - trust_risk) / engineer_weeks
-ship_if(priority_score >= threshold && false_positive_risk <= max_risk)
-```
-
-### Planned Public Interfaces
-
-| Interface | Contract Intent | Status |
-|---|---|---|
-| Plugin API v1 | Deterministic rule hooks with semver guarantees and compatibility tests | planned |
-| Output schema versioning policy | Additive-only changes inside a major schema, explicit migration notes on major bumps | planned |
-| Cache behavior contract | Defined invalidation keys, TTL semantics, and correctness guarantees | planned |
-| Cloud feature boundary | Formal split between free local guardrails and paid cloud intelligence endpoints | planned |
-
-## Execution Model (3-5 engineers)
-
-This roadmap assumes one small team with hard focus discipline, not a platform org. A 3-engineer baseline can run with one runtime owner (scanner/checker/fixer), one ecosystem owner (distribution/integrations/release), and one cloud owner (auth/AI/billing). A 5-engineer variant adds a dedicated plugin-runtime owner and a dedicated growth instrumentation owner.
-
-Delivery cadence should be two-week iterations with one explicit gate review at the end of each phase. Work-in-progress must stay capped: at most one major architectural stream and one distribution stream in flight at the same time. If a stream misses its KPI gate, the next phase does not start. The goal is compounding reliability and adoption, not parallel feature theater.
-
-## The Honest Assessment
-
-Doclify is not early because of missing functionality. It is early because it has not converted technical depth into trusted distribution. The product already has meaningful capability: 35 built-in rules, deterministic scoring, strong test coverage, drift analysis, and CI outputs. But in this category, capability is table stakes. Winning comes from trust, low-friction workflow embedding, and ecosystem contracts others can build on.
-
-If this roadmap is executed with discipline, Doclify can become a default docs-quality gate for OSS maintainers and then convert the most serious maintainers into paying teams through cloud intelligence. If execution drifts into feature accumulation without release coherence, false-positive reduction, and integration ownership, adoption will stall and paid conversion will remain aspirational.
+**Risultato**: ecosystem plugin attivo (>5 plugin), scan incrementale, almeno un style guide pack, benchmark pubblico. Target: >30 utenti paganti, >8000 npm download/settimana.

--- a/test/guardrail.test.mjs
+++ b/test/guardrail.test.mjs
@@ -562,7 +562,8 @@ test('parseArgs: --report with custom path', () => {
 
 test('generateReport: produces valid markdown with findings', () => {
   const tmp = makeTempDir();
-  const reportPath = path.join(tmp, 'report.md');
+  const previousCwd = process.cwd();
+  const reportPath = 'report.md';
 
   const output = {
     version: '1.0',
@@ -584,28 +585,89 @@ test('generateReport: produces valid markdown with findings', () => {
     }
   };
 
-  const result = generateReport(output, { reportPath });
-  assert.ok(fs.existsSync(result), 'Report file should exist');
-  const content = fs.readFileSync(result, 'utf8');
-  assert.ok(content.includes('# Doclify Guardrail Report'), 'Should have title');
-  assert.ok(content.includes('test.md'), 'Should contain filename');
-  assert.ok(content.includes('ERROR'), 'Should contain error details');
-  assert.ok(content.includes('WARNING'), 'Should contain warning details');
+  try {
+    process.chdir(tmp);
+    const result = generateReport(output, { reportPath });
+    assert.ok(fs.existsSync(result), 'Report file should exist');
+    const content = fs.readFileSync(result, 'utf8');
+    assert.ok(content.includes('# Doclify Guardrail Report'), 'Should have title');
+    assert.ok(content.includes('test.md'), 'Should contain filename');
+    assert.ok(content.includes('ERROR'), 'Should contain error details');
+    assert.ok(content.includes('WARNING'), 'Should contain warning details');
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('generateReport: rejects report path outside workspace', () => {
+  const tmp = makeTempDir();
+  const previousCwd = process.cwd();
+
+  const output = {
+    version: '1.0',
+    strict: false,
+    files: [],
+    summary: {
+      filesScanned: 0,
+      filesPassed: 0,
+      filesFailed: 0,
+      filesErrored: 0,
+      totalErrors: 0,
+      totalWarnings: 0,
+      status: 'PASS',
+      elapsed: 0.01
+    }
+  };
+
+  try {
+    process.chdir(tmp);
+    assert.throws(
+      () => generateReport(output, { reportPath: '../outside.md' }),
+      /inside workspace/i
+    );
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
 });
 
 test('CLI: --report writes file to disk', () => {
   const tmp = makeTempDir();
-  const mdPath = path.join(tmp, 'doc.md');
-  const reportPath = path.join(tmp, 'report.md');
-  fs.writeFileSync(mdPath, '# Titolo\nTODO: fix', 'utf8');
+  const mdPath = 'doc.md';
+  const reportPath = 'doclify-report.md';
+  fs.writeFileSync(path.join(tmp, mdPath), '# Titolo\nTODO: fix', 'utf8');
 
   const run = spawnSync(process.execPath, [CLI_PATH, mdPath, '--report', reportPath], {
+    cwd: tmp,
     encoding: 'utf8'
   });
 
-  assert.ok(fs.existsSync(reportPath), 'Report file should be created');
-  const content = fs.readFileSync(reportPath, 'utf8');
+  assert.equal(run.status, 0);
+  assert.ok(fs.existsSync(path.join(tmp, reportPath)), 'Report file should be created');
+  const content = fs.readFileSync(path.join(tmp, reportPath), 'utf8');
   assert.ok(content.includes('Doclify Guardrail Report'));
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('CLI: --report rejects path traversal outside workspace', () => {
+  const tmp = makeTempDir();
+  const mdPath = 'doc.md';
+  const outsideName = `outside-${Date.now()}-${Math.round(Math.random() * 1e9)}.md`;
+  const traversalTarget = `../${outsideName}`;
+  const absoluteOutside = path.resolve(tmp, traversalTarget);
+  fs.writeFileSync(path.join(tmp, mdPath), '# Titolo\nTODO: fix', 'utf8');
+
+  const run = spawnSync(process.execPath, [CLI_PATH, mdPath, '--report', traversalTarget], {
+    cwd: tmp,
+    encoding: 'utf8'
+  });
+
+  assert.equal(run.status, 2);
+  assert.ok(run.stderr.includes('Failed to write report:'), 'stderr should include report failure prefix');
+  assert.ok(run.stderr.match(/inside workspace/i), 'stderr should include workspace boundary reason');
+  assert.equal(fs.existsSync(absoluteOutside), false, 'outside file must not be created');
+  fs.rmSync(tmp, { recursive: true, force: true });
 });
 
 // === Custom rules tests ===
@@ -643,6 +705,33 @@ test('loadCustomRules: rejects invalid regex', () => {
   }), 'utf8');
 
   assert.throws(() => loadCustomRules(rulesPath), /bad-regex/);
+});
+
+test('loadCustomRules: rejects unsafe nested quantifier regex', () => {
+  const tmp = makeTempDir();
+  const rulesPath = path.join(tmp, 'rules.json');
+  fs.writeFileSync(rulesPath, JSON.stringify({
+    rules: [
+      { id: 'redos-risk', severity: 'warning', pattern: '(a+)+$', message: 'bad' }
+    ]
+  }), 'utf8');
+
+  assert.throws(() => loadCustomRules(rulesPath), /redos-risk.*ReDoS/i);
+});
+
+test('loadCustomRules: allows grouped fixed quantifiers', () => {
+  const tmp = makeTempDir();
+  const rulesPath = path.join(tmp, 'rules.json');
+  fs.writeFileSync(rulesPath, JSON.stringify({
+    rules: [
+      { id: 'fixed-group', severity: 'warning', pattern: '([a-z]{2})+', message: 'ok' }
+    ]
+  }), 'utf8');
+
+  const rules = loadCustomRules(rulesPath);
+  assert.equal(rules.length, 1);
+  assert.equal(rules[0].id, 'fixed-group');
+  assert.ok(rules[0].pattern instanceof RegExp);
 });
 
 test('custom rule detects pattern with line number', () => {
@@ -698,6 +787,26 @@ test('CLI: --rules applies custom rules', () => {
   const parsed = JSON.parse(run.stdout);
   const errors = parsed.files[0].findings.errors;
   assert.ok(errors.some(e => e.code === 'no-foo'), 'Custom rule should produce error');
+});
+
+test('CLI: --rules rejects unsafe nested quantifier pattern', () => {
+  const tmp = makeTempDir();
+  const mdPath = path.join(tmp, 'doc.md');
+  const rulesPath = path.join(tmp, 'rules.json');
+  fs.writeFileSync(mdPath, '# Title\ntext', 'utf8');
+  fs.writeFileSync(rulesPath, JSON.stringify({
+    rules: [
+      { id: 'redos-risk', severity: 'warning', pattern: '(a+)+$', message: 'bad' }
+    ]
+  }), 'utf8');
+
+  const run = spawnSync(process.execPath, [CLI_PATH, mdPath, '--rules', rulesPath], {
+    encoding: 'utf8'
+  });
+
+  assert.equal(run.status, 2);
+  assert.ok(run.stderr.includes('Custom rules error:'), 'stderr should include custom-rules error prefix');
+  assert.ok(run.stderr.match(/redos-risk.*ReDoS/i), 'stderr should include unsafe regex details');
 });
 
 // === Color output tests ===
@@ -841,6 +950,26 @@ test('CLI: --fix modifies file on disk', () => {
   assert.equal(run.status, 0);
   const updated = fs.readFileSync(mdPath, 'utf8');
   assert.ok(updated.includes('https://example.com'));
+});
+
+test('CLI: --fix reports user-friendly error when file write fails', () => {
+  const tmp = makeTempDir();
+  const mdPath = path.join(tmp, 'readonly.md');
+  fs.writeFileSync(mdPath, '# Title\nVisit http://example.com', 'utf8');
+  fs.chmodSync(mdPath, 0o444);
+
+  try {
+    const run = spawnSync(process.execPath, [CLI_PATH, mdPath, '--fix', '--json'], { encoding: 'utf8' });
+    assert.equal(run.status, 1);
+    const parsed = JSON.parse(run.stdout);
+    assert.ok(Array.isArray(parsed.fileErrors), 'Should expose fileErrors in JSON output');
+    assert.equal(parsed.fileErrors.length, 1);
+    assert.ok(parsed.fileErrors[0].error.includes('Unable to write fixed file'), 'Should contain user-facing write prefix');
+    assert.ok(parsed.fileErrors[0].error.includes('readonly.md'), 'Should contain target filename');
+  } finally {
+    fs.chmodSync(mdPath, 0o644);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
 });
 
 test('checkDeadLinks: reports missing local file links', async () => {
@@ -1584,12 +1713,19 @@ test('inline suppression: comma-separated rule ids are supported', () => {
   assert.equal(lineLength.length, 0);
 });
 
-test('inline suppression: doclify-enable without rules re-enables all', () => {
-  const md = `# Title\n<!-- doclify-disable placeholder -->\nTODO hidden\n<!-- doclify-enable -->\nTODO visible`;
+test('inline suppression: doclify-enable without rules re-enables global block suppressions', () => {
+  const md = `# Title\n<!-- doclify-disable -->\nTODO hidden\n<!-- doclify-enable -->\nTODO visible`;
   const res = checkMarkdown(md);
   const todoWarnings = res.warnings.filter((w) => w.code === 'placeholder' && w.message.includes('TODO marker'));
   assert.equal(todoWarnings.length, 1);
   assert.equal(todoWarnings[0].line, 5);
+});
+
+test('inline suppression: doclify-enable without rules keeps specific disables active', () => {
+  const md = `# Title\n<!-- doclify-disable placeholder -->\nTODO hidden specific\n<!-- doclify-disable -->\nTODO hidden global\n<!-- doclify-enable -->\nTODO still hidden specific`;
+  const res = checkMarkdown(md);
+  const todoWarnings = res.warnings.filter((w) => w.code === 'placeholder' && w.message.includes('TODO marker'));
+  assert.equal(todoWarnings.length, 0);
 });
 
 test('inline suppression directives do not trigger placeholder warnings', () => {
@@ -2242,6 +2378,38 @@ test('diff: getChangedMarkdownFiles includes .mdx files', () => {
     const files = getChangedMarkdownFiles({ base: 'HEAD' });
     assert.equal(files.length, 1);
     assert.ok(files[0].endsWith('guide.mdx'));
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('diff: getChangedFiles rejects base refs starting with "-"', () => {
+  const tmp = makeTempDir();
+  const previousCwd = process.cwd();
+
+  try {
+    process.chdir(tmp);
+    assert.throws(
+      () => getChangedFiles({ base: '--force' }),
+      /Invalid --base value: must not start with "-"/
+    );
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('diff: getChangedMarkdownFiles rejects base refs starting with "-"', () => {
+  const tmp = makeTempDir();
+  const previousCwd = process.cwd();
+
+  try {
+    process.chdir(tmp);
+    assert.throws(
+      () => getChangedMarkdownFiles({ base: '--force' }),
+      /Invalid --base value: must not start with "-"/
+    );
   } finally {
     process.chdir(previousCwd);
     fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
# Fase 0 — Sicurezza e bug fix

## Cosa fa questa PR

Chiude tutte e 5 le vulnerabilità e bug critici identificati nella Fase 0 della roadmap. L'obiettivo è portare il progetto a zero vulnerabilità note prima di procedere con le fasi successive. Ogni fix è stato progettato per essere minimale, fail-fast, e zero-dependency, coerente con la filosofia del progetto.

## Modifiche per task

### Task 1: Fix ReDoS nelle custom rules
**File**: `src/rules-loader.mjs`
**Problema**: `loadCustomRules()` accettava qualsiasi regex senza validazione. Pattern tipo `(a+)+$` causavano catastrophic backtracking, bloccando Node indefinitamente.
**Soluzione**: Aggiunta funzione `assertRegexIsSafe()` con detection euristica di nested quantifier. Il pattern viene analizzato prima di `new RegExp()` e rifiutato se presenta rischio ReDoS.
**Scelta tecnica**: Validazione euristica locale (state machine su gruppi e quantificatori) invece di libreria esterna (`safe-regex`), perché il progetto è zero-dependency e il pattern nested quantifier copre il caso critico richiesto dalla roadmap. Non intercetta ogni forma di ReDoS, ma riduce il rischio principale.
**Test**: `loadCustomRules: rejects unsafe nested quantifier regex` (unit), `CLI: --rules rejects unsafe nested quantifier pattern` (CLI, verifica exit code 2 e messaggio stderr).

### Task 2: Fix path traversal in report
**File**: `src/report.mjs`
**Problema**: `generateReport()` scriveva il report in qualsiasi path senza controllo. Con `--report ../../etc/passwd` si poteva scrivere fuori dal progetto.
**Soluzione**: Aggiunto gate `isDescendantOrSame()` che verifica, dopo `path.resolve()`, che il path canonico del report sia dentro `process.cwd()`. Helper `canonicalizeForBoundaryCheck()` gestisce anche bypass via symlink nella parent.
**Scelta tecnica**: Boundary fisso su `process.cwd()` con helper locale in `report.mjs` invece di utility condivisa, per ridurre coupling fra moduli. La canonicalizzazione usa `fs.realpathSync` per file esistenti e parent-based resolution per file nuovi.
**Test**: `generateReport: rejects report path outside workspace` (unit), `CLI: --report rejects path traversal outside workspace` (CLI, verifica exit code 2, messaggio stderr, e file esterno non creato).

### Task 3: Fix git argument injection
**File**: `src/diff.mjs`
**Problema**: `assertSafeBaseRef()` bloccava metacaratteri shell ma non ref che iniziano con `-`. Un `--exec=malicious` passava come ref Git valida, causando option injection nel comando `git diff`.
**Soluzione**: Aggiunto check `base.startsWith('-')` in `assertSafeBaseRef()`, con errore dedicato "must not start with -". Il check resta centralizzato in `diff.mjs` per coprire sia CLI che uso programmatico.
**Scelta tecnica**: Blocco di qualsiasi ref con prefisso `-` invece di normalizzazione via `rev-parse`, perché più semplice e senza round-trip aggiuntivi. Nomi di ref con prefisso `-` sono non-convenzionali e possono essere rifiutati.
**Test**: `diff: getChangedFiles rejects base refs starting with "-"`, `diff: getChangedMarkdownFiles rejects base refs starting with "-"` (unit), test CLI su metacaratteri shell resta verde.

### Task 4: Fix bug suppression map
**File**: `src/checker.mjs`
**Problema**: `<!-- doclify-enable -->` senza regole chiamava `activeDisables.clear()` che cancellava TUTTO, incluse le soppressioni specifiche per regola. Un `doclify-disable placeholder` seguito da `doclify-disable` + `doclify-enable` perdeva il disable di `placeholder`.
**Soluzione**: Sostituito `activeDisables.clear()` con `activeDisables.delete('*')` nel ramo `ruleIds === null` di `buildSuppressionMap()`. Così si chiude solo il disable globale, preservando i disable specifici.
**Scelta tecnica**: Fix minimale sulla riga incriminata (1 riga cambiata) invece di riscrittura della macchina a stati. Il modello `Map<ruleId, count>` con nesting resta invariato.
**Test**: `inline suppression: doclify-enable without rules keeps specific disables active` (unit, verifica che TODO dopo enable globale resti soppresso se c'è disable specifico attivo).

### Task 5: Fix crash filesystem
**File**: `src/index.mjs`
**Problema**: `writeFileSync` nel ramo `--fix` senza try/catch. Disco pieno, permessi, o path inesistente = stack trace non gestito.
**Soluzione**: Wrappato `writeFileSync` + `recordSelfWrite` in try/catch locale. L'errore viene ri-lanciato con prefisso `Unable to write fixed file "<path>"` e motivo originale, poi gestito dal `fileErrors[]` esistente.
**Scelta tecnica**: try/catch locale nel ramo write di `runScan()` invece di handler globale, per contestualizzare l'errore con il file specifico. `recordSelfWrite` è dentro il `try` dopo la write: se la write fallisce, non viene registrata come self-write in watch mode.
**Test**: `CLI: --fix reports user-friendly error when file write fails` (CLI, file chmod 444, verifica `fileErrors` in JSON con prefisso e filename).

## Come verificare

### Setup
```bash
git checkout fase0/sicurezza-e-bugfix
npm install
npm test  # tutti i 244 test devono passare
```

### Verifica manuale per ogni fix

**ReDoS** — Crea un file rules con regex pericolosa:
```bash
echo '{ "rules": [{"id":"bad","pattern":"(a+)+$","message":"x","severity":"warning"}] }' > /tmp/bad.json
doclify scan README.md --rules /tmp/bad.json
# Atteso: errore "Rule "bad": unsafe regex pattern (possible ReDoS via nested quantifier)", exit code 2
```

**Path traversal** — Prova a scrivere fuori dal progetto:
```bash
doclify scan README.md --report ../../outside
# Atteso: errore "Report path must be inside workspace", exit code 2
```

**Git injection** — Prova ref malevola:
```bash
node -e "import {getChangedFiles} from './src/diff.mjs'; getChangedFiles({base:'--exec=echo'})" 
# Atteso: errore "Invalid --base value: must not start with \"-\""
```

**Suppression map** — File test:
```markdown
<!-- doclify-disable placeholder -->
TODO A
<!-- doclify-disable -->
TODO B
<!-- doclify-enable -->
TODO C (ancora soppresso per placeholder)
```
```bash
doclify scan test-file.md --json
# Atteso: 0 warning placeholder — il disable specifico sopravvive all'enable globale
```

**Crash filesystem** — File non scrivibile:
```bash
echo '# Title\nhttp://example.com' > /tmp/ro.md && chmod 444 /tmp/ro.md
doclify scan /tmp/ro.md --fix --json
# Atteso: fileErrors con "Unable to write fixed file", nessun stack trace
```

## Rischi e note

- **Nessuna deviazione dalle spec**: tutte le 5 implementazioni sono allineate ai criteri di done documentati in `specs/fase0/`.
- **Roadmap aggiornata**: lo status della Fase 0 è stato corretto da `todo` a `done` (le singole task erano già `done`).
- **Il check ReDoS è euristico**: non intercetta ogni forma di ReDoS (es. backreference pathological), ma copre i nested quantifier che sono il caso critico. Accettabile per Fase 0.
- **Il parser CLI blocca `--base "--exec=echo"` prima di `diff.mjs`**: il flag viene interpretato come opzione CLI sconosciuta. Il fix in `diff.mjs` copre comunque l'uso programmatico diretto di `getChangedFiles()`.

## Checklist pre-merge

- [x] `npm test` tutto verde (244/244 pass)
- [x] Smoke test manuali eseguiti (5/5 passati)
- [x] Nessuna regressione su `doclify scan` base
- [x] Roadmap aggiornata con tutti gli status `done`
- [x] Spec in `specs/fase0/` complete e coerenti con il codice

🤖 Generated with [Claude Code](https://claude.com/claude-code)