### PR TITLE
Release v2.0.0-beta.1

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -16,6 +16,7 @@ on:
       - 'scripts/**'
       - 'test/**'
       - 'action/**'
+      - 'bench/baselines/perf-300.json'
       - 'package.json'
   pull_request:
     paths:
@@ -29,6 +30,7 @@ on:
       - 'scripts/**'
       - 'test/**'
       - 'action/**'
+      - 'bench/baselines/perf-300.json'
       - 'package.json'
 
 jobs:
@@ -55,7 +57,6 @@ jobs:
       - name: Run isolated correctness profile
         run: npm run test:correctness
       - name: Run 300-document performance profile
-        continue-on-error: true
         run: npm run test:performance
       - name: Verify docs sync
         run: npm run docs:sync-check

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -52,8 +52,11 @@ jobs:
       - name: Audit action dependency chain
         working-directory: action
         run: npm audit --omit=dev
-      - name: Run test suite
-        run: npm test
+      - name: Run isolated correctness profile
+        run: npm run test:correctness
+      - name: Run 300-document performance profile
+        continue-on-error: true
+        run: npm run test:performance
       - name: Verify docs sync
         run: npm run docs:sync-check
       - name: Verify npm package contents

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,11 +1,12 @@
 # Doclify Guardrail v2 Migration Contract
 
-Status: approved product decision; not implemented or released
+Status: approved product decision; implementation in progress; not released
 
 The current stable release is `doclify-guardrail@1.7.4`. This document records
 the public-surface decisions for v2 so implementation can proceed without
-hidden compatibility branches. It does not claim that the v2 commands below
-exist today, and it does not announce an npm package or GitHub Action release.
+hidden compatibility branches. It does not claim that every v2 command below
+is implemented, and it does not announce an npm package or GitHub Action
+release.
 
 ## Naming Decision
 
@@ -125,9 +126,9 @@ changed by this decision-only task.
 | `--json` | Migrate | `--format json` |
 | `--format default` | Migrate | `--format text` |
 | `--format compact` | Maintain | `--format compact` |
-| no output limit flag | Add | Text and compact output are bounded by default; `--all` shows every finding. |
+| no output limit flag | Add | Text and compact finding details are capped by default; `--all` shows every finding. Machine formats remain complete. |
 | no common output path | Add | `--output <path>` is the only explicit report-file write. |
-| `--no-color` | Maintain | Applies to human-readable output. |
+| `--no-color` | Maintain | Accepted for compatibility; v2 human-readable output is always color-free. |
 | `--ascii` | Remove | V2 human output uses portable text without a separate ASCII mode. |
 | `--debug` | Remove | Operational errors remain structured; no unbounded debug stream is part of the public contract. |
 | `-h`, `--help` | Maintain | Help for the selected command. |
@@ -172,6 +173,59 @@ changed by this decision-only task.
 | operational diagnostics on stderr | Maintain | Stderr never carries a second machine result and does not alter the structured stdout document. |
 | `--output <path>` | Add | Write the selected result format to that explicit path; operational diagnostics remain on stderr. |
 
+## V2 Result Contract
+
+The explicit `check` and `changed` command paths use one deterministic result
+model. The legacy no-command v1 path continues to emit `schemaVersion: 2` until
+its separately documented removal; consumers must not treat the two envelopes
+as interchangeable.
+
+The v2 envelope contains:
+
+- `schemaVersion: 3` and the exact tool name and package version;
+- `command`, `complete`, and `status`;
+- stable summary counts for selected, scanned, and skipped files, blocking and
+  advisory findings, operational diagnostics, and files with suppressions;
+- a sorted `files` list that distinguishes scanned files, skipped files, and
+  files containing suppression directives;
+- one sorted, flat `findings` list with rule id, severity, confidence, path,
+  position, message, and evidence;
+- a separate sorted `diagnostics` list for operational failures.
+
+`status` is `fail` when blocking findings exist, `incomplete` when no blocking
+finding exists but any selected target could not be scanned, and `pass` only
+when the scan is complete with no blocking finding. A skipped file reports
+`findings: null`, never zero. V1 checker findings are exposed only as
+`advisory`, with `confidence: unverified` and `evidence: null`, until a later
+rule task supplies the precision and proof required for blocking severity.
+
+The result arrays and every machine format are complete. Text and compact cap
+finding details at 50 by default, report how many findings were omitted, and
+accept `--all` to show every finding. Operational diagnostics are never
+truncated. Volatile ids, timestamps, and timings are not part of the result;
+JUnit has no generated timestamp.
+
+Directory recursion does not follow symbolic links. Markdown file links are
+scanned when their resolved target remains inside the selected workspace;
+broken links and links outside that boundary are operational diagnostics.
+
+The programmatic entry point is asynchronous and returns exactly the result
+serialized by the CLI for the same paths and options:
+
+```js
+import { check } from 'doclify-guardrail/api';
+
+const result = await check({
+  paths: ['README.md'],
+  cwd: process.cwd()
+});
+```
+
+Partial scans, including scans where every selected file is unreadable, resolve
+with an incomplete result. Invalid usage or configuration and failures with no
+usable target or diagnostic reject with an error carrying a stable `code`; no
+second public error-class export is required.
+
 ## Programmatic API Migration
 
 The v2 package has no package-root import. The only public programmatic entry
@@ -214,7 +268,7 @@ through the package `bin` field.
 | `doclify-disable-next-line`, `doclify-disable`/`doclify-enable`, and `doclify-disable-file` comments | Maintain | The prefix and scopes remain; removed or renamed rule ids require migration and unknown ids are rejected. |
 | `DOCLIFY_TOKEN`, `DOCLIFY_API_URL`, and `DOCLIFY_PROJECT_ID` | Remove | No Cloud credentials or project binding in v2. |
 | `DOCLIFY_HOME` and `DOCLIFY_REPO_ID` | Remove | No repository memory or hidden per-user state in the v2 core. |
-| `NO_COLOR` | Maintain | Standard color opt-out for human-readable output. |
+| `NO_COLOR` | Maintain | Accepted for compatibility; v2 human-readable output is always color-free. |
 | `.doclify-history.json` | Remove | No score history. |
 | `doclify-report.md` | Remove | No implicit Markdown report. |
 | `doclify-junit.xml` | Migrate | Written only through `--format junit --output <path>`. |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,308 @@
+# Doclify Guardrail v2 Migration Contract
+
+Status: approved product decision; not implemented or released
+
+The current stable release is `doclify-guardrail@1.7.4`. This document records
+the public-surface decisions for v2 so implementation can proceed without
+hidden compatibility branches. It does not claim that the v2 commands below
+exist today, and it does not announce an npm package or GitHub Action release.
+
+## Naming Decision
+
+The v2 npm package remains `doclify-guardrail`. The canonical executable is
+`doclify-guardrail`. The shorter `doclify` executable is removed in v2; users
+who stay on `doclify-guardrail@1` keep both existing executables unchanged.
+
+The exact v2 package and Action description is:
+
+> Deterministic, local, read-only documentation integrity checks for Markdown
+> repositories.
+
+This wording intentionally makes no promise about Cloud services, generative
+AI, or an affected-document review product.
+
+### Name evidence
+
+The technical collision check was performed on 2026-08-08. It is not a legal
+or trademark clearance.
+
+| Surface | Observed evidence | Decision |
+| --- | --- | --- |
+| npm `doclify-guardrail` | The registry reports `1.7.4` on `latest`. | Keep the owned package name. |
+| npm `doclify` | The registry returns `404 Not Found`. | Do not claim the generic package name. |
+| GitHub `Doclify` names | GitHub search returns several unrelated repositories named `Doclify`. | Keep the existing scoped repository identity. |
+| PyPI `doclify` | PyPI publishes an unrelated `doclify` package with a `doclify` CLI. | Remove the short v2 executable to avoid a PATH collision. |
+| `doclify.io` | An unrelated content-management product uses the name. | Do not position the product as plain `Doclify`. |
+
+Sources: [npm package](https://registry.npmjs.org/doclify-guardrail),
+[npm short-name lookup](https://registry.npmjs.org/doclify),
+[GitHub repository search](https://github.com/search?q=doclify&type=repositories),
+[PyPI package](https://pypi.org/project/doclify/), and
+[doclify.io](https://doclify.io/).
+
+## Compatibility Boundary
+
+- `doclify-guardrail@1` remains on the npm `latest` dist-tag until a stable v2
+  release is separately authorized and verified.
+- Any v2 beta uses the npm `next` dist-tag and therefore requires an explicit
+  install or upgrade.
+- `Elgabor/doclify-guardrail/action@v1` remains on the v1 implementation and
+  contract. It is never repointed to the v2 core.
+- A future Action v2 uses a separate `@v2` line. That line does not exist yet.
+- Removed v1 surfaces fail with a stable migration error when the owning v2
+  task removes them. They are not silently accepted or emulated.
+- The v2 result envelope uses `schemaVersion: 3`. Version 2 is already the
+  public JSON schema number emitted by v1.7.4 and cannot be reused for a
+  different result shape.
+
+## Package and Executable Migration
+
+| v1 surface | Decision | v2 destination |
+| --- | --- | --- |
+| npm package `doclify-guardrail` | Maintain | Same package name. |
+| executable `doclify-guardrail` | Maintain | Canonical executable in examples, help, errors, and generated instructions. |
+| executable `doclify` | Remove | Use `doclify-guardrail`; the v1 executable remains available only on `@1`. |
+| Node.js `>=20` | Maintain | Node.js 20 remains the minimum supported runtime. |
+| package export `.` | Remove | Package-root imports fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`; use the explicit API subpath. |
+| package export `./api` | Migrate | Keep `doclify-guardrail/api` with the reduced v2 API below. |
+
+After upgrading to v2, a shell invocation of `doclify` may resolve to an
+unrelated executable, including the PyPI package named `doclify`, instead of
+failing with `command not found`. Replace scripts and local commands with
+`doclify-guardrail` before upgrading.
+
+No package name, executable, export map, version, description, or dist-tag is
+changed by this decision-only task.
+
+## CLI Migration
+
+### Commands and target selection
+
+| v1 surface | Decision | v2 destination |
+| --- | --- | --- |
+| `doclify [files...]` or `doclify-guardrail [files...]` | Migrate | `doclify-guardrail check [paths...]` |
+| no target, which scans the current directory | Maintain | `doclify-guardrail check` scans the selected workspace. |
+| `--dir <path>` | Migrate | Pass the directory as a positional path to `check`. |
+| `--diff` | Migrate | `doclify-guardrail changed --base <ref>` |
+| `--base <ref>` | Maintain | `changed --base <ref>` |
+| `--staged` | Migrate | `doclify-guardrail changed --staged` |
+| stdin unsupported | Add | `check - --stdin-name <name>`; the name is required. |
+| no rule explanation command | Add | `doclify-guardrail explain <rule-id>` |
+
+### Scan policy and configuration flags
+
+| v1 flag | Decision | v2 destination |
+| --- | --- | --- |
+| `--strict` | Remove | Blocking is determined by evidence-backed severity; advisory findings do not become blocking through a global switch. |
+| `--min-score <n>` | Remove | Use blocking, advisory, and operational counts; v2 has no health score. |
+| `--max-line-length <n>` | Remove | Use a dedicated style linter. |
+| `--config <path>` | Maintain | Explicit v2 configuration path. |
+| `--rules <path>` | Remove | Regex rule plugins are not part of the v2 core; future policy work is not promised by this migration. |
+| `--ignore-rules <list>` | Maintain | Explicit local rule override. |
+| `--exclude <list>` | Maintain | Explicit path exclusion inside the selected workspace. |
+| `--check-links` | Migrate | Local link integrity is part of the core; use `--external-links` to opt into network checks. |
+| `--allow-private-links` | Remove | V2 does not expose a switch that weakens private, loopback, link-local, or metadata-address protections. |
+| `--site-root <path>` | Maintain | Root for local root-relative link resolution, contained within the selected workspace. |
+| `--link-allow-list <list>` | Maintain | Applies only when `--external-links` is present. |
+| `--link-timeout-ms <n>` | Maintain | Applies only when `--external-links` is present. |
+| `--link-concurrency <n>` | Maintain | Applies only when `--external-links` is present. |
+| `--check-freshness` | Remove | Time-based freshness heuristics are not part of the v2 integrity core. |
+| `--freshness-max-days <n>` | Remove | No replacement in the v2 integrity core. |
+| `--check-frontmatter` | Remove | Generic frontmatter style enforcement is not part of the v2 integrity core. |
+| `--check-inline-html` | Remove | Use an MDX/Markdown-aware style or security tool for this policy. |
+
+### Writes, output, and terminal flags
+
+| v1 flag | Decision | v2 destination |
+| --- | --- | --- |
+| `--fix` | Remove | No integrated document rewriting in v2. |
+| `--dry-run` | Remove | No fixer to preview. |
+| `--report [path]` | Remove | Markdown report generation is not part of the v2 core. |
+| `--junit [path]` | Migrate | `--format junit` writes to stdout; add `--output <path>` for an explicit file write. |
+| `--sarif [path]` | Migrate | `--format sarif` writes to stdout; add `--output <path>` for an explicit file write. |
+| `--badge [path]` | Remove | V2 has no health score or badge. |
+| `--badge-label <text>` | Remove | V2 has no badge. |
+| `--json` | Migrate | `--format json` |
+| `--format default` | Migrate | `--format text` |
+| `--format compact` | Maintain | `--format compact` |
+| no output limit flag | Add | Text and compact output are bounded by default; `--all` shows every finding. |
+| no common output path | Add | `--output <path>` is the only explicit report-file write. |
+| `--no-color` | Maintain | Applies to human-readable output. |
+| `--ascii` | Remove | V2 human output uses portable text without a separate ASCII mode. |
+| `--debug` | Remove | Operational errors remain structured; no unbounded debug stream is part of the public contract. |
+| `-h`, `--help` | Maintain | Help for the selected command. |
+| `-v`, `--version` | Maintain | Print the package version. |
+| `--list-rules` | Remove | V2 does not preserve rule enumeration; use `explain <rule-id>` for a known supported rule. |
+
+### Setup, watch, score, Cloud, and AI surfaces
+
+| v1 surface | Decision | v2 destination |
+| --- | --- | --- |
+| `init` | Migrate | `init --print`; it does not write. |
+| `init --force` | Remove | `init --write` is the explicit write and refuses to hide an existing configuration. |
+| `--watch` | Remove | Re-run `check` or `changed` from the caller's existing watch workflow. |
+| `--track` | Remove | No score history in v2. |
+| `--trend` | Remove | No score trend in v2. |
+| `--fail-on-regression` | Remove | No score regression gate in v2. |
+| `login --key <apiKey>` and its `--api-url`/`--json` flags | Remove | No Cloud login or credential store in v2. |
+| `whoami` and its `--json` flag | Remove | No Cloud identity in v2. |
+| `logout` | Remove | No Cloud credential store in v2. |
+| `--push` | Remove | No Cloud score push in v2. |
+| `--project-id <id>` | Remove | No Cloud project binding in v2. |
+| `--api-url <url>` | Remove | No Cloud API in the v2 core. |
+| `--token <apiKey>` | Remove | No Cloud token input in the v2 core. |
+| `--ai-drift` | Remove | No Drift Guard compatibility path in the v2 core. |
+| `--ai-mode <mode>` | Remove | No AI engine mode in the v2 core. |
+| `--fail-on-drift <level>` | Remove | No heuristic drift gate in the v2 core. |
+| `--fail-on-drift-scope <scope>` | Remove | No heuristic drift gate in the v2 core. |
+| `ai drift [target]` and its `--diff`, `--staged`, `--base`, `--mode`, `--json`, `--fail-on-drift`, `--fail-on-drift-scope`, `--api-url`, and `--token` flags | Remove | No compatibility command in v2. |
+| `ai memory export` and its `--json` flag | Remove | No repository memory surface in v2. |
+| reserved `ai fix`, `ai prioritize`, and `ai coverage` commands | Remove | Unsupported stubs do not migrate. |
+
+### Exit codes and output channels
+
+| v1 surface | Decision | v2 destination |
+| --- | --- | --- |
+| exit `0` | Maintain | Complete scan with no blocking or operational findings. |
+| exit `1` | Migrate | Blocking findings, or a partial scan whose structured result remains usable. There is no strict-mode warning gate. |
+| exit `2` | Migrate | Invalid usage or configuration, or a total execution failure with no usable scan result. |
+| human output on stderr | Migrate | Text and compact results move to stdout; operational diagnostics remain on stderr. |
+| JSON on stdout | Maintain | Emit exactly one valid JSON document, with no human logs in that document. |
+| SARIF and JUnit written to implicit or flag-specific files | Migrate | Emit exactly one valid document in the selected format on stdout unless `--output` names an explicit file. |
+| operational diagnostics on stderr | Maintain | Stderr never carries a second machine result and does not alter the structured stdout document. |
+| `--output <path>` | Add | Write the selected result format to that explicit path; operational diagnostics remain on stderr. |
+
+## Programmatic API Migration
+
+The v2 package has no package-root import. The only public programmatic entry
+point is `doclify-guardrail/api`. Its `check` function returns the same
+`schemaVersion: 3` result model observed by the CLI.
+
+| v1 export | Current import | Decision | v2 destination |
+| --- | --- | --- | --- |
+| `lint` | `doclify-guardrail/api` | Migrate | `check`, returning the shared v2 result model. |
+| `fix` | `doclify-guardrail/api` | Remove | No write API. |
+| `score` | `doclify-guardrail/api` | Remove | No health score. |
+| `RULE_CATALOG` | `doclify-guardrail/api` | Remove | Use the stable rule ids in results and the CLI `explain` command. |
+| `checkMarkdown` | package root | Remove | Use `check` from `doclify-guardrail/api`. |
+| `parseArgs` | package root | Remove | Internal CLI implementation. |
+| `resolveOptions` | package root | Remove | Internal configuration implementation. |
+| `resolveFileOptions` | package root | Remove | Internal configuration implementation. |
+| `findParentConfigs` | package root | Remove | Internal filesystem implementation. |
+| `runCli` | package root | Remove | Internal CLI implementation. |
+| `buildFileResult` | package root | Remove | Internal result implementation. |
+| `buildOutput` | package root | Remove | Internal result implementation. |
+
+Removing the package-root export means `import 'doclify-guardrail'` fails in
+v2. The executables are independent of the export map and remain addressable
+through the package `bin` field.
+
+## Configuration, Environment, and Generated Files
+
+| v1 surface | Decision | v2 destination |
+| --- | --- | --- |
+| `.doclify-guardrail.json` | Maintain | Same configuration filename and hierarchical lookup, with deterministic workspace-contained resolution. |
+| `ignoreRules` | Maintain | Same suppression mechanism; removed or renamed rule ids require migration and unknown ids are rejected. |
+| `exclude` | Maintain | Same purpose, contained within the selected workspace. |
+| `siteRoot` | Maintain | Same purpose, contained within the selected workspace. |
+| `linkAllowList` | Maintain | Same purpose for explicit external-link checks. |
+| `linkTimeoutMs` | Maintain | Same purpose for explicit external-link checks. |
+| `linkConcurrency` | Maintain | Same purpose for explicit external-link checks. |
+| `checkLinks` | Migrate | `externalLinks`; local integrity checks do not require network opt-in. |
+| `strict`, `maxLineLength`, `checkFreshness`, `freshnessMaxDays`, `checkFrontmatter`, and `checkInlineHtml` | Remove | No v2 core replacement. |
+| `push` and `projectId` | Remove | No Cloud configuration in v2. |
+| `doclify-disable-next-line`, `doclify-disable`/`doclify-enable`, and `doclify-disable-file` comments | Maintain | The prefix and scopes remain; removed or renamed rule ids require migration and unknown ids are rejected. |
+| `DOCLIFY_TOKEN`, `DOCLIFY_API_URL`, and `DOCLIFY_PROJECT_ID` | Remove | No Cloud credentials or project binding in v2. |
+| `DOCLIFY_HOME` and `DOCLIFY_REPO_ID` | Remove | No repository memory or hidden per-user state in the v2 core. |
+| `NO_COLOR` | Maintain | Standard color opt-out for human-readable output. |
+| `.doclify-history.json` | Remove | No score history. |
+| `doclify-report.md` | Remove | No implicit Markdown report. |
+| `doclify-junit.xml` | Migrate | Written only through `--format junit --output <path>`. |
+| `doclify.sarif` | Migrate | Written only through `--format sarif --output <path>`. |
+| `doclify-badge.svg` | Remove | No score badge. |
+| local auth state under `.doclify/` | Remove | No Cloud credential store. |
+
+## GitHub Action Migration
+
+Every input and output below remains unchanged for
+`Elgabor/doclify-guardrail/action@v1`. The v2 destination applies only to a
+future, separately tested `@v2` Action.
+
+### Inputs
+
+| Action v1 input | Decision for Action v2 | v2 destination |
+| --- | --- | --- |
+| `path` | Maintain | Single selected path passed to `check`. |
+| `strict` | Remove | Evidence-backed blocking severity is the gate. |
+| `min-score` | Remove | V2 has no health score. |
+| `check-links` | Migrate | `external-links`; local integrity checks are part of the core. |
+| `check-freshness` | Remove | No freshness heuristic in the v2 core. |
+| `check-frontmatter` | Remove | No generic frontmatter style gate in the v2 core. |
+| `ai-drift` | Remove | No Drift Guard in the v2 core. |
+| `ai-mode` | Remove | No AI mode in the v2 core. |
+| `fail-on-drift` | Remove | No heuristic drift gate in the v2 core. |
+| `fail-on-drift-scope` | Remove | No heuristic drift gate in the v2 core. |
+| `api-url` | Remove | No Cloud API in the v2 core. |
+| `doclify-token` | Remove | The base v2 Action requires no Doclify token. |
+| `push` | Remove | No Cloud score push. |
+| `project-id` | Remove | No Cloud project binding. |
+| `format` | Migrate | `text`, `compact`, `json`, `sarif`, or `junit`, backed by one result model. |
+| `sarif` | Migrate | Set `format: sarif`. |
+| `sarif-file` | Migrate | Set the explicit v2 `output` input. |
+| `pr-comment` | Remove | The v2 Action emits annotations and outputs without a default PR-comment write. |
+| `token` | Remove | The base v2 Action does not request a GitHub token for PR comments. |
+| `output` (new in v2) | Add | Explicit destination for the selected machine or human result format. |
+
+### Outputs
+
+| Action v1 output | Decision for Action v2 | v2 destination |
+| --- | --- | --- |
+| `score` | Remove | No health score. |
+| `status` | Maintain | PASS or FAIL derived from the shared v2 result. |
+| `errors` | Remove | Read blocking and operational counts from the v2 result artifact. |
+| `warnings` | Remove | Read advisory counts from the v2 result artifact. |
+
+The Action v1 bundle, metadata, inputs, outputs, runtime behavior, and tags are
+not changed or rebuilt by this decision-only migration contract.
+
+## MDX Boundary
+
+MDX is not a first-class v2 syntax. Files ending in `.mdx` are selected but use
+the limited `fragment` preset by default:
+
+- no `single-h1` requirement;
+- JSX, imports, exports, and expressions are treated as opaque content and are
+  never executed;
+- prose rules do not inspect JSX markup;
+- only deterministic checks that are safe on the Markdown portions run;
+- Doclify does not claim to validate MDX syntax or dynamic references.
+
+First-class MDX parsing would require separate evidence, fixtures, dependency
+review, and an explicit product decision.
+
+## Migration Examples
+
+Stay on the current v1 contract:
+
+```sh
+npm install --save-dev doclify-guardrail@^1
+npx doclify README.md
+```
+
+The planned v2 opt-in is:
+
+```sh
+npm install --save-dev doclify-guardrail@next
+npx doclify-guardrail check README.md
+```
+
+The second example is not executable until a v2 beta is implemented,
+authorized for publication on `next`, and verified from the npm registry.
+
+Existing Action users remain on:
+
+```yaml
+- uses: Elgabor/doclify-guardrail/action@v1
+```
+
+There is no supported `@v2` Action reference yet.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -90,6 +90,20 @@ changed by this decision-only task.
 | stdin unsupported | Add | `check - --stdin-name <name>`; the name is required. |
 | no rule explanation command | Add | `doclify-guardrail explain <rule-id>` |
 
+`changed` discovers the Git root once from the invocation directory and runs
+the selected diff there. Result paths are relative to that Git root, so the
+same invocation produces the same machine result from the repository root or
+one of its subdirectories, including linked worktrees. `check` paths remain
+relative to its selected `cwd` workspace.
+
+Both changed selectors include tracked added, copied, modified, and renamed
+Markdown files. Rename results use only the current path. Deleted, untracked,
+and ignored files are not scanned. Filename parsing is zero-delimited, so
+spaces, non-ASCII text, tabs, and newlines do not change selection. Missing Git,
+a non-repository directory, an unknown base ref, and other Git failures use the
+stable `git-unavailable`, `not-a-git-repository`, `unknown-base-ref`, and
+`git-failed` usage-error codes.
+
 ### Scan policy and configuration flags
 
 | v1 flag | Decision | v2 destination |
@@ -219,6 +233,12 @@ const result = await check({
   paths: ['README.md'],
   cwd: process.cwd()
 });
+
+const changedResult = await check({
+  command: 'changed',
+  changed: { base: 'origin/main' },
+  cwd: process.cwd()
+});
 ```
 
 Partial scans, including scans where every selected file is unreadable, resolve
@@ -255,14 +275,14 @@ through the package `bin` field.
 
 | v1 surface | Decision | v2 destination |
 | --- | --- | --- |
-| `.doclify-guardrail.json` | Maintain | Same configuration filename and hierarchical lookup, with deterministic workspace-contained resolution. |
+| `.doclify-guardrail.json` | Maintain | Same configuration filename and hierarchical lookup, with deterministic repository-contained resolution. |
 | `ignoreRules` | Maintain | Same suppression mechanism; removed or renamed rule ids require migration and unknown ids are rejected. |
 | `exclude` | Maintain | Same purpose, contained within the selected workspace. |
-| `siteRoot` | Maintain | Same purpose, contained within the selected workspace. |
+| `siteRoot` | Maintain | Same purpose, contained within the Git root when available and otherwise within the selected workspace. |
 | `linkAllowList` | Maintain | Same purpose for explicit external-link checks. |
 | `linkTimeoutMs` | Maintain | Same purpose for explicit external-link checks. |
 | `linkConcurrency` | Maintain | Same purpose for explicit external-link checks. |
-| `checkLinks` | Migrate | `externalLinks`; local integrity checks do not require network opt-in. |
+| `checkLinks` | Remove | No configuration file can enable network access; use the explicit CLI `--external-links` flag or API `externalLinks: true`. |
 | `strict`, `maxLineLength`, `checkFreshness`, `freshnessMaxDays`, `checkFrontmatter`, and `checkInlineHtml` | Remove | No v2 core replacement. |
 | `push` and `projectId` | Remove | No Cloud configuration in v2. |
 | `doclify-disable-next-line`, `doclify-disable`/`doclify-enable`, and `doclify-disable-file` comments | Maintain | The prefix and scopes remain; removed or renamed rule ids require migration and unknown ids are rejected. |
@@ -275,6 +295,36 @@ through the package `bin` field.
 | `doclify.sarif` | Migrate | Written only through `--format sarif --output <path>`. |
 | `doclify-badge.svg` | Remove | No score badge. |
 | local auth state under `.doclify/` | Remove | No Cloud credential store. |
+
+Automatic configuration lookup starts at the Git root and applies files from
+that root through the scanned file's directory. Without Git, lookup starts at
+the selected workspace and never reads a parent directory, including a user
+home. Each configuration file is read at most once per scan and no Git process
+is created per file.
+
+Scalars use the closest configuration value. `ignoreRules`, `exclude`, and
+`linkAllowList` are additive and deduplicated. Relative `siteRoot` and `exclude`
+values use the directory containing the configuration that declares them;
+nested exclusions apply only below that directory and prune traversal before
+an excluded subtree is read. Explicit CLI and API options apply last. Selected
+documents remain contained within the selected workspace. `siteRoot` remains
+inside the Git root when one is available and otherwise inside the selected
+workspace, so repository-root link resolution is stable when `check` runs from
+a subdirectory.
+
+`--config <path>` and API `config` select exactly one required file, resolved
+from the invocation directory, inside the Git root when available and otherwise
+inside the workspace, and disable automatic hierarchy. Removed v1 keys fail with
+`config-removed-key`; unknown keys fail with `config-unknown-key`; missing,
+malformed, and out-of-bound explicit configuration use `config-not-found`,
+`config-invalid`, and `config-outside-workspace`. V1 configuration is not
+silently accepted by the explicit v2 commands.
+
+Configuration is untrusted input and cannot opt into external requests.
+`externalLinks` is therefore not a configuration key; only the explicit CLI
+flag or API option enables remote checks. Configuration may tune
+`linkAllowList`, `linkTimeoutMs`, and `linkConcurrency`, but those values remain
+inert while external checks are disabled.
 
 ## GitHub Action Migration
 

--- a/action/dist/index.mjs
+++ b/action/dist/index.mjs
@@ -4173,7 +4173,13 @@ function processHeader (request, key, val) {
       } else if (typeof val[i] === 'object') {
         throw new InvalidArgumentError(`invalid ${key} header`)
       } else {
-        arr.push(`${val[i]}`)
+        // Coerce primitives (and reject unsafe coercions such as functions
+        // with a crafted toString/Symbol.toPrimitive).
+        const str = `${val[i]}`
+        if (!isValidHeaderValue(str)) {
+          throw new InvalidArgumentError(`invalid ${key} header`)
+        }
+        arr.push(str)
       }
     }
     val = arr
@@ -4184,7 +4190,12 @@ function processHeader (request, key, val) {
   } else if (val === null) {
     val = ''
   } else {
+    // Coerce primitives (and reject unsafe coercions such as functions
+    // with a crafted toString/Symbol.toPrimitive).
     val = `${val}`
+    if (!isValidHeaderValue(val)) {
+      throw new InvalidArgumentError(`invalid ${key} header`)
+    }
   }
 
   if (headerName === 'host') {
@@ -5218,8 +5229,6 @@ function defaultFactory (origin, opts) {
 
 class Agent extends DispatcherBase {
   constructor ({ factory = defaultFactory, maxRedirections = 0, connect, ...options } = {}) {
-    super()
-
     if (typeof factory !== 'function') {
       throw new InvalidArgumentError('factory must be a function.')
     }
@@ -5231,6 +5240,8 @@ class Agent extends DispatcherBase {
     if (!Number.isInteger(maxRedirections) || maxRedirections < 0) {
       throw new InvalidArgumentError('maxRedirections must be a positive number')
     }
+
+    super(options)
 
     if (connect && typeof connect !== 'function') {
       connect = { ...connect }
@@ -5556,6 +5567,7 @@ const {
   RequestContentLengthMismatchError,
   ResponseContentLengthMismatchError,
   RequestAbortedError,
+  InvalidArgumentError,
   HeadersTimeoutError,
   HeadersOverflowError,
   SocketError,
@@ -5603,6 +5615,9 @@ const EMPTY_BUF = Buffer.alloc(0)
 const FastBuffer = Buffer[Symbol.species]
 const addListener = util.addListener
 const removeAllListeners = util.removeAllListeners
+const kIdleSocketValidation = Symbol('kIdleSocketValidation')
+const kIdleSocketValidationTimeout = Symbol('kIdleSocketValidationTimeout')
+const kSocketUsed = Symbol('kSocketUsed')
 
 let extractBody
 
@@ -5825,27 +5840,69 @@ class Parser {
 
       const offset = llhttp.llhttp_get_error_pos(this.ptr) - currentBufferPtr
 
-      if (ret === constants.ERROR.PAUSED_UPGRADE) {
-        this.onUpgrade(data.slice(offset))
-      } else if (ret === constants.ERROR.PAUSED) {
-        this.paused = true
-        socket.unshift(data.slice(offset))
-      } else if (ret !== constants.ERROR.OK) {
-        const ptr = llhttp.llhttp_get_error_reason(this.ptr)
-        let message = ''
-        /* istanbul ignore else: difficult to make a test case for */
-        if (ptr) {
-          const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0)
-          message =
-            'Response does not match the HTTP/1.1 protocol (' +
-            Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
-            ')'
+      if (ret !== constants.ERROR.OK) {
+        const body = data.subarray(offset)
+
+        if (ret === constants.ERROR.PAUSED_UPGRADE) {
+          this.onUpgrade(body)
+        } else if (ret === constants.ERROR.PAUSED) {
+          this.paused = true
+          socket.unshift(body)
+        } else {
+          throw this.createError(ret, body)
         }
-        throw new HTTPParserError(message, constants.ERROR[ret], data.slice(offset))
       }
     } catch (err) {
       util.destroy(socket, err)
     }
+  }
+
+  finish () {
+    assert(currentParser === null)
+    assert(this.ptr != null)
+    assert(!this.paused)
+
+    const { llhttp } = this
+
+    let ret
+
+    try {
+      currentParser = this
+      ret = llhttp.llhttp_finish(this.ptr)
+    } finally {
+      currentParser = null
+    }
+
+    if (ret === constants.ERROR.OK) {
+      return null
+    }
+
+    if (ret === constants.ERROR.PAUSED || ret === constants.ERROR.PAUSED_UPGRADE) {
+      this.paused = true
+      return null
+    }
+
+    return this.createError(ret, EMPTY_BUF)
+  }
+
+  createError (ret, data) {
+    const { llhttp, contentLength, bytesRead } = this
+
+    if (contentLength && bytesRead !== parseInt(contentLength, 10)) {
+      return new ResponseContentLengthMismatchError()
+    }
+
+    const ptr = llhttp.llhttp_get_error_reason(this.ptr)
+    let message = ''
+    if (ptr) {
+      const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0)
+      message =
+        'Response does not match the HTTP/1.1 protocol (' +
+        Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
+        ')'
+    }
+
+    return new HTTPParserError(message, constants.ERROR[ret], data)
   }
 
   destroy () {
@@ -5872,6 +5929,11 @@ class Parser {
 
     /* istanbul ignore next: difficult to make a test case for */
     if (socket.destroyed) {
+      return -1
+    }
+
+    if (client[kRunning] === 0) {
+      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)))
       return -1
     }
 
@@ -5975,6 +6037,11 @@ class Parser {
 
     /* istanbul ignore next: difficult to make a test case for */
     if (socket.destroyed) {
+      return -1
+    }
+
+    if (client[kRunning] === 0) {
+      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)))
       return -1
     }
 
@@ -6151,6 +6218,7 @@ class Parser {
     request.onComplete(headers)
 
     client[kQueue][client[kRunningIdx]++] = null
+    socket[kSocketUsed] = true
 
     if (socket[kWriting]) {
       assert(client[kRunning] === 0)
@@ -6209,6 +6277,9 @@ async function connectH1 (client, socket) {
   socket[kWriting] = false
   socket[kReset] = false
   socket[kBlocking] = false
+  socket[kIdleSocketValidation] = 0
+  socket[kIdleSocketValidationTimeout] = null
+  socket[kSocketUsed] = false
   socket[kParser] = new Parser(client, socket, llhttpInstance)
 
   addListener(socket, 'error', function (err) {
@@ -6219,8 +6290,11 @@ async function connectH1 (client, socket) {
     // On Mac OS, we get an ECONNRESET even if there is a full body to be forwarded
     // to the user.
     if (err.code === 'ECONNRESET' && parser.statusCode && !parser.shouldKeepAlive) {
-      // We treat all incoming data so for as a valid response.
-      parser.onMessageComplete()
+      const parserErr = parser.finish()
+      if (parserErr) {
+        this[kError] = parserErr
+        this[kClient][kOnError](parserErr)
+      }
       return
     }
 
@@ -6239,8 +6313,10 @@ async function connectH1 (client, socket) {
     const parser = this[kParser]
 
     if (parser.statusCode && !parser.shouldKeepAlive) {
-      // We treat all incoming data so far as a valid response.
-      parser.onMessageComplete()
+      const parserErr = parser.finish()
+      if (parserErr) {
+        util.destroy(this, parserErr)
+      }
       return
     }
 
@@ -6250,10 +6326,11 @@ async function connectH1 (client, socket) {
     const client = this[kClient]
     const parser = this[kParser]
 
+    clearIdleSocketValidation(this)
+
     if (parser) {
       if (!this[kError] && parser.statusCode && !parser.shouldKeepAlive) {
-        // We treat all incoming data so far as a valid response.
-        parser.onMessageComplete()
+        this[kError] = parser.finish() || this[kError]
       }
 
       this[kParser].destroy()
@@ -6316,7 +6393,7 @@ async function connectH1 (client, socket) {
       return socket.destroyed
     },
     busy (request) {
-      if (socket[kWriting] || socket[kReset] || socket[kBlocking]) {
+      if (socket[kWriting] || socket[kReset] || socket[kBlocking] || socket[kIdleSocketValidation] === 1) {
         return true
       }
 
@@ -6354,6 +6431,31 @@ async function connectH1 (client, socket) {
   }
 }
 
+function clearIdleSocketValidation (socket) {
+  if (socket[kIdleSocketValidationTimeout]) {
+    clearTimeout(socket[kIdleSocketValidationTimeout])
+    socket[kIdleSocketValidationTimeout] = null
+  }
+
+  socket[kIdleSocketValidation] = 0
+}
+
+function scheduleIdleSocketValidation (client, socket) {
+  socket[kIdleSocketValidation] = 1
+  socket[kIdleSocketValidationTimeout] = setTimeout(() => {
+    socket[kIdleSocketValidationTimeout] = null
+    socket[kIdleSocketValidation] = 2
+
+    if (client[kSocket] === socket && !socket.destroyed) {
+      client[kResume]()
+    }
+  }, 0)
+  socket[kIdleSocketValidationTimeout].unref?.()
+}
+
+/**
+ * @param {import('./client.js')} client
+ */
 function resumeH1 (client) {
   const socket = client[kSocket]
 
@@ -6366,6 +6468,32 @@ function resumeH1 (client) {
     } else if (socket[kNoRef] && socket.ref) {
       socket.ref()
       socket[kNoRef] = false
+    }
+
+    if (client[kRunning] === 0 && client[kPending] > 0 && socket[kSocketUsed]) {
+      if (socket[kIdleSocketValidation] === 0) {
+        scheduleIdleSocketValidation(client, socket)
+        socket[kParser].readMore()
+        if (socket.destroyed) {
+          return
+        }
+        return
+      }
+
+      if (socket[kIdleSocketValidation] === 1) {
+        socket[kParser].readMore()
+        if (socket.destroyed) {
+          return
+        }
+        return
+      }
+    }
+
+    if (client[kRunning] === 0) {
+      socket[kParser].readMore()
+      if (socket.destroyed) {
+        return
+      }
     }
 
     if (client[kSize] === 0) {
@@ -6423,8 +6551,16 @@ function writeH1 (client, request) {
     }
     body = bodyStream.stream
     contentLength = bodyStream.length
-  } else if (util.isBlobLike(body) && request.contentType == null && body.type) {
-    headers.push('content-type', body.type)
+  } else if (util.isBlobLike(body) && request.contentType == null) {
+    const contentType = body.type
+    if (contentType) {
+      const contentTypeValue = `${contentType}`
+      if (!util.isValidHeaderValue(contentTypeValue)) {
+        util.errorRequest(client, request, new InvalidArgumentError('invalid content-type header'))
+        return false
+      }
+      headers.push('content-type', contentTypeValue)
+    }
   }
 
   if (body && typeof body.read === 'function') {
@@ -6461,6 +6597,7 @@ function writeH1 (client, request) {
   }
 
   const socket = client[kSocket]
+  clearIdleSocketValidation(socket)
 
   const abort = (err) => {
     if (request.aborted || request.completed) {
@@ -7780,9 +7917,10 @@ class Client extends DispatcherBase {
     autoSelectFamilyAttemptTimeout,
     // h2
     maxConcurrentStreams,
-    allowH2
+    allowH2,
+    webSocket
   } = {}) {
-    super()
+    super({ webSocket })
 
     if (keepAlive !== undefined) {
       throw new InvalidArgumentError('unsupported keepAlive, use pipelining=0 instead')
@@ -8314,15 +8452,24 @@ const { kDestroy, kClose, kClosed, kDestroyed, kDispatch, kInterceptors } = __nc
 const kOnDestroyed = Symbol('onDestroyed')
 const kOnClosed = Symbol('onClosed')
 const kInterceptedDispatch = Symbol('Intercepted Dispatch')
+const kWebSocketOptions = Symbol('webSocketOptions')
 
 class DispatcherBase extends Dispatcher {
-  constructor () {
+  constructor (opts) {
     super()
 
     this[kDestroyed] = false
     this[kOnDestroyed] = null
     this[kClosed] = false
     this[kOnClosed] = []
+    this[kWebSocketOptions] = opts?.webSocket ?? {}
+  }
+
+  get webSocketOptions () {
+    return {
+      maxFragments: this[kWebSocketOptions].maxFragments ?? 131072,
+      maxPayloadSize: this[kWebSocketOptions].maxPayloadSize ?? 128 * 1024 * 1024
+    }
   }
 
   get destroyed () {
@@ -8882,8 +9029,8 @@ const kRemoveClient = Symbol('remove client')
 const kStats = Symbol('stats')
 
 class PoolBase extends DispatcherBase {
-  constructor () {
-    super()
+  constructor (opts) {
+    super(opts)
 
     this[kQueue] = new FixedQueue()
     this[kClients] = []
@@ -9142,8 +9289,6 @@ class Pool extends PoolBase {
     allowH2,
     ...options
   } = {}) {
-    super()
-
     if (connections != null && (!Number.isFinite(connections) || connections < 0)) {
       throw new InvalidArgumentError('invalid connections')
     }
@@ -9167,6 +9312,8 @@ class Pool extends PoolBase {
         ...connect
       })
     }
+
+    super(options)
 
     this[kInterceptors] = options.interceptors?.Pool && Array.isArray(options.interceptors.Pool)
       ? options.interceptors.Pool
@@ -9886,6 +10033,28 @@ function calculateRetryAfterHeader (retryAfter) {
   return new Date(retryAfter).getTime() - current
 }
 
+function validatePartialResponseContentLength (headers, range, statusCode, retryCount) {
+  const contentLength = headers['content-length']
+  if (contentLength == null) {
+    return null
+  }
+
+  if (!Number.isFinite(range.start) || !Number.isFinite(range.end)) {
+    return null
+  }
+
+  const length = Number(contentLength)
+  const expectedLength = range.end - range.start + 1
+  if (!Number.isFinite(length) || length !== expectedLength) {
+    return new RequestRetryError('Content-Length mismatch', statusCode, {
+      headers,
+      data: { count: retryCount }
+    })
+  }
+
+  return null
+}
+
 class RetryHandler {
   constructor (opts, handlers) {
     const { retryOptions, ...dispatchOpts } = opts
@@ -10100,6 +10269,12 @@ class RetryHandler {
         return false
       }
 
+      const contentLengthError = validatePartialResponseContentLength(headers, contentRange, statusCode, this.retryCount)
+      if (contentLengthError != null) {
+        this.abort(contentLengthError)
+        return false
+      }
+
       const { start, size, end = size - 1 } = contentRange
 
       assert(this.start === start, 'content-range mismatch')
@@ -10121,6 +10296,12 @@ class RetryHandler {
             resume,
             statusMessage
           )
+        }
+
+        const contentLengthError = validatePartialResponseContentLength(headers, range, statusCode, this.retryCount)
+        if (contentLengthError != null) {
+          this.abort(contentLengthError)
+          return false
         }
 
         const { start, size, end = size - 1 } = range
@@ -14220,32 +14401,25 @@ function parseUnparsedAttributes (unparsedAttributes, cookieAttributeList = {}) 
     // If the attribute-name case-insensitively matches the string
     // "SameSite", the user agent MUST process the cookie-av as follows:
 
-    // 1. Let enforcement be "Default".
-    let enforcement = 'Default'
-
     const attributeValueLowercase = attributeValue.toLowerCase()
-    // 2. If cookie-av's attribute-value is a case-insensitive match for
-    //    "None", set enforcement to "None".
-    if (attributeValueLowercase.includes('none')) {
-      enforcement = 'None'
-    }
 
-    // 3. If cookie-av's attribute-value is a case-insensitive match for
-    //    "Strict", set enforcement to "Strict".
-    if (attributeValueLowercase.includes('strict')) {
-      enforcement = 'Strict'
+    // 1. If cookie-av's attribute-value is a case-insensitive match for
+    //    "None", append an attribute to the cookie-attribute-list with an
+    //    attribute-name of "SameSite" and an attribute-value of "None".
+    if (attributeValueLowercase === 'none') {
+      cookieAttributeList.sameSite = 'None'
+    } else if (attributeValueLowercase === 'strict') {
+      // 2. If cookie-av's attribute-value is a case-insensitive match for
+      //    "Strict", append an attribute to the cookie-attribute-list with
+      //    an attribute-name of "SameSite" and an attribute-value of
+      //    "Strict".
+      cookieAttributeList.sameSite = 'Strict'
+    } else if (attributeValueLowercase === 'lax') {
+      // 3. If cookie-av's attribute-value is a case-insensitive match for
+      //    "Lax", append an attribute to the cookie-attribute-list with an
+      //    attribute-name of "SameSite" and an attribute-value of "Lax".
+      cookieAttributeList.sameSite = 'Lax'
     }
-
-    // 4. If cookie-av's attribute-value is a case-insensitive match for
-    //    "Lax", set enforcement to "Lax".
-    if (attributeValueLowercase.includes('lax')) {
-      enforcement = 'Lax'
-    }
-
-    // 5. Append an attribute to the cookie-attribute-list with an
-    //    attribute-name of "SameSite" and an attribute-value of
-    //    enforcement.
-    cookieAttributeList.sameSite = enforcement
   } else {
     cookieAttributeList.unparsed ??= []
 
@@ -14374,7 +14548,7 @@ function validateCookiePath (path) {
 
     if (
       code < 0x20 || // exclude CTLs (0-31)
-      code === 0x7F || // DEL
+      code > 0x7E || // exclude DEL and non-ascii
       code === 0x3B // ;
     ) {
       throw new Error('Invalid cookie path')
@@ -14383,16 +14557,80 @@ function validateCookiePath (path) {
 }
 
 /**
- * I have no idea why these values aren't allowed to be honest,
- * but Deno tests these. - Khafra
+ * <let-dig> ::= <letter> | <digit>
+ *
+ * <letter> ::= any one of the 52 alphabetic characters A through Z in
+ * upper case and a through z in lower case
+ *
+ * <digit> ::= any one of the ten digits 0 through 9r
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc1034#section-3.5
+ * @param {number} code
+ */
+function isLetterOrDigit (code) {
+  return (
+    (code >= 0x30 && code <= 0x39) || // 0-9
+    (code >= 0x41 && code <= 0x5A) || // A-Z
+    (code >= 0x61 && code <= 0x7A) // a-z
+  )
+}
+
+/**
+ * Validates a cookie domain against the "preferred name syntax".
+ *
+ * <domain>      ::= <subdomain> | " "
+ * <subdomain>   ::= <label> | <subdomain> "." <label>
+ * <label>       ::= <let-dig> [ [ <ldh-str> ] <let-dig> ]
+ * <ldh-str>     ::= <let-dig-hyp> | <let-dig-hyp> <ldh-str>
+ * <let-dig-hyp> ::= <let-dig> | "-"
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc1034#section-3.5
+ * @see https://www.rfc-editor.org/rfc/rfc1123#section-2.1
+ * @see https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4
  * @param {string} domain
  */
 function validateCookieDomain (domain) {
-  if (
-    domain.startsWith('-') ||
-    domain.endsWith('.') ||
-    domain.endsWith('-')
-  ) {
+  // <domain> ::= <subdomain> | " "
+  if (domain === ' ') {
+    return
+  }
+
+  if (domain.length > 255) {
+    throw new Error('Invalid cookie domain')
+  }
+
+  let labelLength = 0
+
+  for (let i = 0; i < domain.length; ++i) {
+    const code = domain.charCodeAt(i)
+
+    if (code === 0x2E) {
+      if (labelLength === 0) {
+        throw new Error('Invalid cookie domain')
+      }
+
+      if (domain.charCodeAt(i - 1) === 0x2D) { // "-"
+        throw new Error('Invalid cookie domain')
+      }
+
+      labelLength = 0
+      continue
+    }
+
+    if (labelLength === 0 && !isLetterOrDigit(code)) {
+      throw new Error('Invalid cookie domain')
+    }
+
+    if (!isLetterOrDigit(code) && code !== 0x2D) { // "-"
+      throw new Error('Invalid cookie domain')
+    }
+
+    if (++labelLength > 63) {
+      throw new Error('Invalid cookie domain')
+    }
+  }
+
+  if (labelLength === 0 || domain.charCodeAt(domain.length - 1) === 0x2D) { // "-"
     throw new Error('Invalid cookie domain')
   }
 }
@@ -14535,7 +14773,13 @@ function stringify (cookie) {
 
     const [key, ...value] = part.split('=')
 
-    out.push(`${key.trim()}=${value.join('=')}`)
+    const trimmedKey = key.trim()
+    const joinedValue = value.join('=')
+
+    validateCookieName(trimmedKey)
+    validateCookieValue(joinedValue)
+
+    out.push(`${trimmedKey}=${joinedValue}`)
   }
 
   return out.join('; ')
@@ -26922,40 +27166,35 @@ const tail = Buffer.from([0x00, 0x00, 0xff, 0xff])
 const kBuffer = Symbol('kBuffer')
 const kLength = Symbol('kLength')
 
-// Default maximum decompressed message size: 4 MB
-const kDefaultMaxDecompressedSize = 4 * 1024 * 1024
-
 class PerMessageDeflate {
   /** @type {import('node:zlib').InflateRaw} */
   #inflate
 
   #options = {}
 
-  /** @type {boolean} */
-  #aborted = false
-
-  /** @type {Function|null} */
-  #currentCallback = null
+  #maxPayloadSize = 0
 
   /**
    * @param {Map<string, string>} extensions
    */
-  constructor (extensions) {
+  constructor (extensions, options) {
     this.#options.serverNoContextTakeover = extensions.has('server_no_context_takeover')
     this.#options.serverMaxWindowBits = extensions.get('server_max_window_bits')
+
+    this.#maxPayloadSize = options.maxPayloadSize
   }
 
+  /**
+   * Decompress a compressed payload.
+   * @param {Buffer} chunk Compressed data
+   * @param {boolean} fin Final fragment flag
+   * @param {Function} callback Callback function
+   */
   decompress (chunk, fin, callback) {
     // An endpoint uses the following algorithm to decompress a message.
     // 1.  Append 4 octets of 0x00 0x00 0xff 0xff to the tail end of the
     //     payload of the message.
     // 2.  Decompress the resulting data using DEFLATE.
-
-    if (this.#aborted) {
-      callback(new MessageSizeExceededError())
-      return
-    }
-
     if (!this.#inflate) {
       let windowBits = Z_DEFAULT_WINDOWBITS
 
@@ -26978,23 +27217,12 @@ class PerMessageDeflate {
       this.#inflate[kLength] = 0
 
       this.#inflate.on('data', (data) => {
-        if (this.#aborted) {
-          return
-        }
-
         this.#inflate[kLength] += data.length
 
-        if (this.#inflate[kLength] > kDefaultMaxDecompressedSize) {
-          this.#aborted = true
+        if (this.#maxPayloadSize > 0 && this.#inflate[kLength] > this.#maxPayloadSize) {
+          callback(new MessageSizeExceededError())
           this.#inflate.removeAllListeners()
-          this.#inflate.destroy()
           this.#inflate = null
-
-          if (this.#currentCallback) {
-            const cb = this.#currentCallback
-            this.#currentCallback = null
-            cb(new MessageSizeExceededError())
-          }
           return
         }
 
@@ -27007,14 +27235,13 @@ class PerMessageDeflate {
       })
     }
 
-    this.#currentCallback = callback
     this.#inflate.write(chunk)
     if (fin) {
       this.#inflate.write(tail)
     }
 
     this.#inflate.flush(() => {
-      if (this.#aborted || !this.#inflate) {
+      if (!this.#inflate) {
         return
       }
 
@@ -27022,7 +27249,6 @@ class PerMessageDeflate {
 
       this.#inflate[kBuffer].length = 0
       this.#inflate[kLength] = 0
-      this.#currentCallback = null
 
       callback(null, full)
     })
@@ -27057,6 +27283,12 @@ const {
 const { WebsocketFrameSend } = __nccwpck_require__(3264)
 const { closeWebSocketConnection } = __nccwpck_require__(6897)
 const { PerMessageDeflate } = __nccwpck_require__(9469)
+const { MessageSizeExceededError } = __nccwpck_require__(8707)
+
+function failWebsocketConnectionWithCode (ws, code, reason) {
+  closeWebSocketConnection(ws, code, reason, Buffer.byteLength(reason))
+  failWebsocketConnection(ws, reason)
+}
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -27065,6 +27297,7 @@ const { PerMessageDeflate } = __nccwpck_require__(9469)
 
 class ByteParser extends Writable {
   #buffers = []
+  #fragmentsBytes = 0
   #byteOffset = 0
   #loop = false
 
@@ -27076,18 +27309,27 @@ class ByteParser extends Writable {
   /** @type {Map<string, PerMessageDeflate>} */
   #extensions
 
+  /** @type {number} */
+  #maxFragments
+
+  /** @type {number} */
+  #maxPayloadSize
+
   /**
    * @param {import('./websocket').WebSocket} ws
    * @param {Map<string, string>|null} extensions
+   * @param {{ maxFragments?: number, maxPayloadSize?: number }} [options]
    */
-  constructor (ws, extensions) {
+  constructor (ws, extensions, options = {}) {
     super()
 
     this.ws = ws
     this.#extensions = extensions == null ? new Map() : extensions
+    this.#maxFragments = options.maxFragments ?? 0
+    this.#maxPayloadSize = options.maxPayloadSize ?? 0
 
     if (this.#extensions.has('permessage-deflate')) {
-      this.#extensions.set('permessage-deflate', new PerMessageDeflate(extensions))
+      this.#extensions.set('permessage-deflate', new PerMessageDeflate(extensions, options))
     }
   }
 
@@ -27101,6 +27343,19 @@ class ByteParser extends Writable {
     this.#loop = true
 
     this.run(callback)
+  }
+
+  #validatePayloadLength () {
+    if (
+      this.#maxPayloadSize > 0 &&
+      !isControlFrame(this.#info.opcode) &&
+      this.#info.payloadLength + this.#fragmentsBytes > this.#maxPayloadSize
+    ) {
+      failWebsocketConnectionWithCode(this.ws, 1009, 'Payload size exceeds maximum allowed size')
+      return false
+    }
+
+    return true
   }
 
   /**
@@ -27191,6 +27446,10 @@ class ByteParser extends Writable {
         if (payloadLength <= 125) {
           this.#info.payloadLength = payloadLength
           this.#state = parserStates.READ_DATA
+
+          if (!this.#validatePayloadLength()) {
+            return
+          }
         } else if (payloadLength === 126) {
           this.#state = parserStates.PAYLOADLENGTH_16
         } else if (payloadLength === 127) {
@@ -27215,6 +27474,10 @@ class ByteParser extends Writable {
 
         this.#info.payloadLength = buffer.readUInt16BE(0)
         this.#state = parserStates.READ_DATA
+
+        if (!this.#validatePayloadLength()) {
+          return
+        }
       } else if (this.#state === parserStates.PAYLOADLENGTH_64) {
         if (this.#byteOffset < 8) {
           return callback()
@@ -27237,6 +27500,10 @@ class ByteParser extends Writable {
 
         this.#info.payloadLength = lower
         this.#state = parserStates.READ_DATA
+
+        if (!this.#validatePayloadLength()) {
+          return
+        }
       } else if (this.#state === parserStates.READ_DATA) {
         if (this.#byteOffset < this.#info.payloadLength) {
           return callback()
@@ -27249,42 +27516,58 @@ class ByteParser extends Writable {
           this.#state = parserStates.INFO
         } else {
           if (!this.#info.compressed) {
-            this.#fragments.push(body)
+            if (!this.writeFragments(body)) {
+              return
+            }
+
+            if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
+              failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message)
+              return
+            }
 
             // If the frame is not fragmented, a message has been received.
             // If the frame is fragmented, it will terminate with a fin bit set
             // and an opcode of 0 (continuation), therefore we handle that when
             // parsing continuation frames, not here.
             if (!this.#info.fragmented && this.#info.fin) {
-              const fullMessage = Buffer.concat(this.#fragments)
-              websocketMessageReceived(this.ws, this.#info.binaryType, fullMessage)
-              this.#fragments.length = 0
+              websocketMessageReceived(this.ws, this.#info.binaryType, this.consumeFragments())
             }
 
             this.#state = parserStates.INFO
           } else {
-            this.#extensions.get('permessage-deflate').decompress(body, this.#info.fin, (error, data) => {
-              if (error) {
-                failWebsocketConnection(this.ws, error.message)
-                return
-              }
+            this.#extensions.get('permessage-deflate').decompress(
+              body,
+              this.#info.fin,
+              (error, data) => {
+                if (error) {
+                  const code = error instanceof MessageSizeExceededError ? 1009 : 1007
+                  failWebsocketConnectionWithCode(this.ws, code, error.message)
+                  return
+                }
 
-              this.#fragments.push(data)
+                if (!this.writeFragments(data)) {
+                  return
+                }
 
-              if (!this.#info.fin) {
-                this.#state = parserStates.INFO
+                if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
+                  failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message)
+                  return
+                }
+
+                if (!this.#info.fin) {
+                  this.#state = parserStates.INFO
+                  this.#loop = true
+                  this.run(callback)
+                  return
+                }
+
+                websocketMessageReceived(this.ws, this.#info.binaryType, this.consumeFragments())
+
                 this.#loop = true
+                this.#state = parserStates.INFO
                 this.run(callback)
-                return
               }
-
-              websocketMessageReceived(this.ws, this.#info.binaryType, Buffer.concat(this.#fragments))
-
-              this.#loop = true
-              this.#state = parserStates.INFO
-              this.#fragments.length = 0
-              this.run(callback)
-            })
+            )
 
             this.#loop = false
             break
@@ -27334,6 +27617,35 @@ class ByteParser extends Writable {
     this.#byteOffset -= n
 
     return buffer
+  }
+
+  writeFragments (fragment) {
+    if (
+      this.#maxFragments > 0 &&
+      this.#fragments.length === this.#maxFragments
+    ) {
+      failWebsocketConnectionWithCode(this.ws, 1008, 'Too many message fragments')
+      return false
+    }
+
+    this.#fragmentsBytes += fragment.length
+    this.#fragments.push(fragment)
+    return true
+  }
+
+  consumeFragments () {
+    const fragments = this.#fragments
+
+    if (fragments.length === 1) {
+      this.#fragmentsBytes = 0
+      return fragments.shift()
+    }
+
+    const output = Buffer.concat(fragments, this.#fragmentsBytes)
+    this.#fragments = []
+    this.#fragmentsBytes = 0
+
+    return output
   }
 
   parseCloseBody (data) {
@@ -28367,7 +28679,14 @@ class WebSocket extends EventTarget {
     // once this happens, the connection is open
     this[kResponse] = response
 
-    const parser = new ByteParser(this, parsedExtensions)
+    const webSocketOptions = this[kController]?.dispatcher?.webSocketOptions
+    const maxFragments = webSocketOptions?.maxFragments
+    const maxPayloadSize = webSocketOptions?.maxPayloadSize
+
+    const parser = new ByteParser(this, parsedExtensions, {
+      maxFragments,
+      maxPayloadSize
+    })
     parser.on('drain', onParserDrain)
     parser.on('error', onParserError.bind(this))
 

--- a/action/package-lock.json
+++ b/action/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/bench/baselines/perf-300.json
+++ b/bench/baselines/perf-300.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "corpus": {
+    "generator": "doclify-perf-corpus-v1",
+    "seed": 1,
+    "documents": 300,
+    "contentHash": "sha256:2c83f51794c53bbe35b289387bec1fc60c022a8dd7cf8f57acf41cfb221ad0c9"
+  },
+  "ruleSet": {
+    "count": 35,
+    "hash": "sha256:dbfeb20f1fb509679b5490349af407586217d0f6dc0423aeb3abc92ef4dc5ff7"
+  },
+  "environments": {
+    "darwin-arm64-node22-fs26": {
+      "environment": {
+        "class": "darwin-arm64-node22-fs26",
+        "node": "v22.22.3",
+        "platform": "darwin",
+        "arch": "arm64",
+        "filesystemType": "26",
+        "cpuModel": "Apple M4",
+        "cpuCount": 10,
+        "totalMemoryMb": 16384,
+        "ci": false
+      },
+      "cold": {
+        "runs": 3,
+        "samplesMs": [88.629, 86.099, 85.028],
+        "p50Ms": 86.099,
+        "p95Ms": 88.376
+      },
+      "warm": {
+        "runs": 10,
+        "samplesMs": [40.229, 38.02, 37.639, 37.672, 37.204, 36.633, 37.386, 36.513, 36.085, 37.19],
+        "p50Ms": 37.295,
+        "p95Ms": 39.235
+      },
+      "deterministic": true
+    }
+  },
+  "tolerance": {
+    "localPct": 50,
+    "ciPct": 150,
+    "absoluteFloorMs": 50
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "doclify-guardrail",
-  "version": "1.7.4",
+  "version": "2.0.0-beta.1",
   "type": "module",
-  "description": "Quality gate for your Markdown docs. Zero dependencies, catches errors in seconds.",
+  "description": "Deterministic, local, read-only documentation integrity checks for Markdown repositories.",
   "homepage": "https://github.com/Elgabor/doclify-guardrail#readme",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   },
   "scripts": {
     "start": "node ./src/index.mjs",
-    "test": "node --test test/*.test.mjs",
+    "test": "npm run test:correctness",
+    "test:correctness": "node ./scripts/check-test-isolation.mjs",
+    "test:performance": "node ./scripts/perf-corpus.mjs",
     "docs:sync-check": "node ./scripts/check-docs-sync.mjs",
     "reliability:pr": "node scripts/run-corpus.mjs --manifest bench/corpus.manifest.json --profile deterministic --tag pr-sample --repeat 2 --out bench/out/pr-deterministic.json && node scripts/compare-baseline.mjs --current bench/out/pr-deterministic.json --baseline bench/baselines/pr-deterministic.json --thresholds bench/reliability-thresholds.json --waivers bench/waivers.json --report bench/out/pr-deterministic-report.md",
     "reliability:nightly:det": "node scripts/run-corpus.mjs --manifest bench/corpus.manifest.json --profile deterministic --tag nightly-det-full --repeat 3 --out bench/out/nightly-deterministic.json && node scripts/compare-baseline.mjs --current bench/out/nightly-deterministic.json --baseline bench/baselines/nightly-deterministic.json --thresholds bench/reliability-thresholds.json --waivers bench/waivers.json --report bench/out/nightly-deterministic-report.md",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "start": "node ./src/index.mjs",
-    "test": "node --test test/guardrail.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "docs:sync-check": "node ./scripts/check-docs-sync.mjs",
     "reliability:pr": "node scripts/run-corpus.mjs --manifest bench/corpus.manifest.json --profile deterministic --tag pr-sample --repeat 2 --out bench/out/pr-deterministic.json && node scripts/compare-baseline.mjs --current bench/out/pr-deterministic.json --baseline bench/baselines/pr-deterministic.json --thresholds bench/reliability-thresholds.json --waivers bench/waivers.json --report bench/out/pr-deterministic-report.md",
     "reliability:nightly:det": "node scripts/run-corpus.mjs --manifest bench/corpus.manifest.json --profile deterministic --tag nightly-det-full --repeat 3 --out bench/out/nightly-deterministic.json && node scripts/compare-baseline.mjs --current bench/out/nightly-deterministic.json --baseline bench/baselines/nightly-deterministic.json --thresholds bench/reliability-thresholds.json --waivers bench/waivers.json --report bench/out/nightly-deterministic-report.md",

--- a/scripts/check-docs-sync.mjs
+++ b/scripts/check-docs-sync.mjs
@@ -113,6 +113,14 @@ const checks = [
         pattern: /run: npm pack --dry-run/
       },
       {
+        label: 'performance baseline trigger',
+        pattern: /'bench\/baselines\/perf-300\.json'/
+      },
+      {
+        label: 'enforced performance profile',
+        pattern: /- name: Run 300-document performance profile\n\s+run: npm run test:performance/
+      },
+      {
         label: 'README-only docs gate',
         pattern: /run: node \.\/src\/index\.mjs README\.md --strict --report report\.md/
       },

--- a/scripts/check-test-isolation.mjs
+++ b/scripts/check-test-isolation.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  captureRepositoryState,
+  compareRepositoryStates,
+  createIsolatedEnvironment,
+  createSandbox,
+  installCleanupHandlers,
+  removeSandbox
+} from './test-isolation.mjs';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = path.resolve(SCRIPT_DIR, '..');
+const THIS_FILE = fileURLToPath(import.meta.url);
+
+function testFiles(repositoryRoot = REPOSITORY_ROOT) {
+  const directory = path.join(repositoryRoot, 'test');
+  return fs.readdirSync(directory)
+    .filter((name) => name.endsWith('.test.mjs'))
+    .sort((left, right) => left.localeCompare(right, 'en'))
+    .map((name) => path.join(directory, name));
+}
+
+function waitForChild(child) {
+  return new Promise((resolve) => {
+    child.once('error', (error) => resolve({ error, status: 1, signal: null }));
+    child.once('exit', (status, signal) => resolve({ error: null, status: status ?? 1, signal }));
+  });
+}
+
+async function runTestProfile(options = {}) {
+  const repositoryRoot = path.resolve(options.repositoryRoot || REPOSITORY_ROOT);
+  const files = options.files || testFiles(repositoryRoot);
+  const output = options.output || { stdout: process.stdout, stderr: process.stderr };
+  const before = captureRepositoryState(repositoryRoot);
+  const sandbox = createSandbox();
+  let child = null;
+  const cleanup = () => {
+    if (child && child.exitCode == null && child.signalCode == null) child.kill('SIGTERM');
+    removeSandbox(sandbox);
+  };
+  const disposeHandlers = installCleanupHandlers(cleanup);
+  let outcome;
+
+  try {
+    const environment = createIsolatedEnvironment(sandbox);
+    child = spawn(process.execPath, ['--test', ...files], {
+      cwd: sandbox,
+      env: environment,
+      stdio: options.stdio || 'inherit'
+    });
+    outcome = await waitForChild(child);
+  } finally {
+    disposeHandlers();
+    removeSandbox(sandbox);
+  }
+
+  let after;
+  try {
+    after = captureRepositoryState(repositoryRoot);
+  } catch (error) {
+    throw new Error(`Repository became uninspectable during the test run: ${error.message}`);
+  }
+  const comparison = compareRepositoryStates(before, after);
+  if (!comparison.unchanged) {
+    output.stderr.write('test-isolation: repository state changed during the test run.\n');
+    if (comparison.gitStatusChanged) output.stderr.write('test-isolation: git status changed.\n');
+    for (const change of comparison.changes) output.stderr.write(`test-isolation: ${change}.\n`);
+    return 1;
+  }
+  if (outcome.error) {
+    output.stderr.write(`test-isolation: unable to launch tests (${outcome.error.code || 'UNKNOWN'}).\n`);
+    return 1;
+  }
+  if (outcome.signal) {
+    output.stderr.write(`test-isolation: test process stopped by ${outcome.signal}.\n`);
+    return 1;
+  }
+  if (outcome.status !== 0) return outcome.status;
+  output.stdout.write('test-isolation: pass | repository unchanged | sandbox removed\n');
+  return 0;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === THIS_FILE) {
+  runTestProfile().then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (error) => {
+      process.stderr.write(`test-isolation: ${error.message}\n`);
+      process.exitCode = 1;
+    }
+  );
+}
+
+export { runTestProfile };

--- a/scripts/perf-corpus.mjs
+++ b/scripts/perf-corpus.mjs
@@ -207,7 +207,10 @@ function comparePerformance(observation, baseline) {
   const tolerance = baseline.tolerance || {};
   const percentage = observation.environment.ci ? tolerance.ciPct : tolerance.localPct;
   const floor = Number(tolerance.absoluteFloorMs || 0);
-  if (!Number.isFinite(percentage) || percentage < 0) {
+  const validP95 = (value) => Number.isFinite(value) && value >= 0;
+  if (!Number.isFinite(percentage) || percentage < 0 || !Number.isFinite(floor) || floor < 0
+    || !validP95(recorded.cold?.p95Ms) || !validP95(recorded.warm?.p95Ms)
+    || !validP95(observation.cold?.p95Ms) || !validP95(observation.warm?.p95Ms)) {
     failures.push('Performance baseline tolerance is invalid.');
     return { pass: false, status: 'fail', failures, limits: null };
   }

--- a/scripts/perf-corpus.mjs
+++ b/scripts/perf-corpus.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { RULE_CATALOG } from '../src/checker.mjs';
+import { check } from '../src/api.mjs';
+import {
+  captureRepositoryState,
+  compareRepositoryStates,
+  createIsolatedEnvironment,
+  createSandbox,
+  installCleanupHandlers,
+  removeSandbox
+} from './test-isolation.mjs';
+
+const THIS_FILE = fileURLToPath(import.meta.url);
+const REPOSITORY_ROOT = path.resolve(path.dirname(THIS_FILE), '..');
+const CLI_PATH = path.join(REPOSITORY_ROOT, 'src', 'index.mjs');
+const BASELINE_PATH = path.join(REPOSITORY_ROOT, 'bench', 'baselines', 'perf-300.json');
+const DOCUMENT_COUNT = 300;
+const GENERATOR_ID = 'doclify-perf-corpus-v1';
+const COLD_RUNS = 3;
+const WARM_RUNS = 10;
+
+function digest(value) {
+  return `sha256:${crypto.createHash('sha256').update(value).digest('hex')}`;
+}
+
+function generateCorpus(root, options = {}) {
+  const count = options.documents || DOCUMENT_COUNT;
+  if (!Number.isInteger(count) || count <= 0 || count % 10 !== 0) {
+    throw new Error('Performance corpus document count must be a positive multiple of 10.');
+  }
+  const hasher = crypto.createHash('sha256');
+  for (let index = 0; index < count; index += 1) {
+    const section = index % 10;
+    const next = (index + 10) % count;
+    const relative = path.join(`section-${String(section).padStart(2, '0')}`, `doc-${String(index).padStart(3, '0')}.md`);
+    const content = [
+      `# Document ${String(index).padStart(3, '0')}`,
+      '',
+      `Deterministic corpus entry ${String(index).padStart(3, '0')}.`,
+      '',
+      `[Next](doc-${String(next).padStart(3, '0')}.md)`,
+      ''
+    ].join('\n');
+    const absolute = path.join(root, relative);
+    fs.mkdirSync(path.dirname(absolute), { recursive: true });
+    fs.writeFileSync(absolute, content, 'utf8');
+    hasher.update(relative.split(path.sep).join('/'));
+    hasher.update('\0');
+    hasher.update(content);
+    hasher.update('\0');
+  }
+  return {
+    generator: GENERATOR_ID,
+    seed: 1,
+    documents: count,
+    contentHash: `sha256:${hasher.digest('hex')}`
+  };
+}
+
+function ruleSetMetadata() {
+  const rules = RULE_CATALOG.map(({ id, severity, description }) => ({ id, severity, description }));
+  return {
+    count: rules.length,
+    hash: digest(JSON.stringify(rules))
+  };
+}
+
+function percentile(values, percentileValue) {
+  const sorted = [...values].sort((left, right) => left - right);
+  const position = (percentileValue / 100) * (sorted.length - 1);
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  if (lower === upper) return sorted[lower];
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
+}
+
+function summarize(samples) {
+  return {
+    runs: samples.length,
+    samplesMs: samples.map((value) => Number(value.toFixed(3))),
+    p50Ms: Number(percentile(samples, 50).toFixed(3)),
+    p95Ms: Number(percentile(samples, 95).toFixed(3))
+  };
+}
+
+function filesystemType(target) {
+  try {
+    return fs.statfsSync(target, { bigint: true }).type.toString();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function environmentMetadata(target) {
+  const cpus = os.cpus();
+  const nodeMajor = Number(process.versions.node.split('.')[0]);
+  const fsType = filesystemType(target);
+  return {
+    class: `${process.platform}-${process.arch}-node${nodeMajor}-fs${fsType}`,
+    node: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    filesystemType: fsType,
+    cpuModel: cpus[0]?.model || 'unknown',
+    cpuCount: cpus.length,
+    totalMemoryMb: Math.round(os.totalmem() / (1024 * 1024)),
+    ci: process.env.CI === 'true'
+  };
+}
+
+function validateResult(result) {
+  if (result?.schemaVersion !== 3 || result?.status !== 'pass'
+    || result?.complete !== true || result?.files?.length !== DOCUMENT_COUNT) {
+    throw new Error('Performance corpus did not produce the expected complete 300-document result.');
+  }
+}
+
+async function runWorker() {
+  const workspace = process.cwd();
+  const corpusRoot = path.join(workspace, 'corpus');
+  const corpus = generateCorpus(corpusRoot);
+  const coldSamples = [];
+  let coldFingerprint = null;
+
+  for (let run = 0; run < COLD_RUNS; run += 1) {
+    const started = performance.now();
+    const child = spawnSync(process.execPath, [CLI_PATH, 'check', 'corpus', '--format', 'json'], {
+      cwd: workspace,
+      env: process.env,
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    coldSamples.push(performance.now() - started);
+    if (child.error || child.status !== 0) {
+      throw new Error(`Cold performance run failed (${child.error?.code || child.status || 'UNKNOWN'}).`);
+    }
+    const parsed = JSON.parse(child.stdout);
+    validateResult(parsed);
+    const fingerprint = digest(JSON.stringify(parsed));
+    if (coldFingerprint && coldFingerprint !== fingerprint) {
+      throw new Error('Cold performance runs produced non-deterministic results.');
+    }
+    coldFingerprint = fingerprint;
+  }
+
+  validateResult(await check({ cwd: workspace, paths: ['corpus'] }));
+  const warmSamples = [];
+  let warmFingerprint = null;
+  for (let run = 0; run < WARM_RUNS; run += 1) {
+    const started = performance.now();
+    const result = await check({ cwd: workspace, paths: ['corpus'] });
+    warmSamples.push(performance.now() - started);
+    validateResult(result);
+    const fingerprint = digest(JSON.stringify(result));
+    if (warmFingerprint && warmFingerprint !== fingerprint) {
+      throw new Error('Warm performance runs produced non-deterministic results.');
+    }
+    warmFingerprint = fingerprint;
+  }
+  if (coldFingerprint !== warmFingerprint) {
+    throw new Error('CLI and API performance runs produced different results.');
+  }
+
+  return {
+    schemaVersion: 1,
+    corpus,
+    ruleSet: ruleSetMetadata(),
+    environment: environmentMetadata(workspace),
+    cold: summarize(coldSamples),
+    warm: summarize(warmSamples),
+    deterministic: true
+  };
+}
+
+function comparePerformance(observation, baseline) {
+  const failures = [];
+  if (baseline?.schemaVersion !== 1) failures.push('Unsupported performance baseline schema.');
+  for (const key of ['generator', 'seed', 'documents', 'contentHash']) {
+    if (observation.corpus?.[key] !== baseline?.corpus?.[key]) {
+      failures.push(`Corpus ${key} does not match the recorded baseline.`);
+    }
+  }
+  if (observation.ruleSet?.count !== baseline?.ruleSet?.count
+    || observation.ruleSet?.hash !== baseline?.ruleSet?.hash) {
+    failures.push('Rule-set hash does not match; record a reviewed baseline for the new rule set.');
+  }
+
+  const recorded = baseline?.environments?.[observation.environment?.class];
+  if (!recorded) {
+    if (failures.length > 0) return { pass: false, status: 'fail', failures, limits: null };
+    return {
+      pass: true,
+      status: 'unrecorded',
+      failures: [],
+      limits: null
+    };
+  }
+  const tolerance = baseline.tolerance || {};
+  const percentage = observation.environment.ci ? tolerance.ciPct : tolerance.localPct;
+  const floor = Number(tolerance.absoluteFloorMs || 0);
+  if (!Number.isFinite(percentage) || percentage < 0) {
+    failures.push('Performance baseline tolerance is invalid.');
+    return { pass: false, status: 'fail', failures, limits: null };
+  }
+  const limitFor = (value) => Number((value + Math.max((value * percentage) / 100, floor)).toFixed(3));
+  const limits = {
+    coldP95Ms: limitFor(recorded.cold.p95Ms),
+    warmP95Ms: limitFor(recorded.warm.p95Ms)
+  };
+  if (observation.cold.p95Ms > limits.coldP95Ms) {
+    failures.push(`Cold p95 ${observation.cold.p95Ms}ms exceeded ${limits.coldP95Ms}ms.`);
+  }
+  if (observation.warm.p95Ms > limits.warmP95Ms) {
+    failures.push(`Warm p95 ${observation.warm.p95Ms}ms exceeded ${limits.warmP95Ms}ms.`);
+  }
+  return {
+    pass: failures.length === 0,
+    status: failures.length === 0 ? 'pass' : 'fail',
+    failures,
+    limits
+  };
+}
+
+function loadBaseline() {
+  try {
+    return JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'));
+  } catch {
+    throw new Error(`Performance baseline is missing or invalid: ${BASELINE_PATH}`);
+  }
+}
+
+function measureIsolated() {
+  const before = captureRepositoryState(REPOSITORY_ROOT);
+  const sandbox = createSandbox();
+  const disposeHandlers = installCleanupHandlers(() => removeSandbox(sandbox));
+  let child;
+  try {
+    child = spawnSync(process.execPath, [THIS_FILE, '--worker'], {
+      cwd: sandbox,
+      env: createIsolatedEnvironment(sandbox),
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+  } finally {
+    disposeHandlers();
+    removeSandbox(sandbox);
+  }
+  let after;
+  try {
+    after = captureRepositoryState(REPOSITORY_ROOT);
+  } catch (error) {
+    throw new Error(`Repository became uninspectable during the performance profile: ${error.message}`);
+  }
+  const repositoryComparison = compareRepositoryStates(before, after);
+  if (!repositoryComparison.unchanged) {
+    throw new Error('Performance profile changed repository state.');
+  }
+  if (child.error || child.status !== 0) {
+    throw new Error(`Performance worker failed: ${child.stderr || child.error?.message || child.status}`);
+  }
+  return JSON.parse(child.stdout);
+}
+
+async function main(argv = process.argv.slice(2)) {
+  if (argv.length > 1 || (argv.length === 1 && !['--worker', '--measure'].includes(argv[0]))) {
+    throw new Error(`Unknown option: ${argv[0]}`);
+  }
+  if (argv[0] === '--worker') {
+    process.stdout.write(`${JSON.stringify(await runWorker())}\n`);
+    return 0;
+  }
+  const observation = measureIsolated();
+  if (argv[0] === '--measure') {
+    process.stdout.write(`${JSON.stringify(observation, null, 2)}\n`);
+    return 0;
+  }
+
+  const comparison = comparePerformance(observation, loadBaseline());
+  if (comparison.status === 'unrecorded') {
+    process.stdout.write(
+      `performance: unrecorded | ${observation.environment.class} | cold p95 ${observation.cold.p95Ms}ms | warm p95 ${observation.warm.p95Ms}ms\n`
+    );
+    return 0;
+  }
+  if (!comparison.pass) {
+    process.stderr.write(
+      `performance: measured ${observation.environment.class} | cold p95 ${observation.cold.p95Ms}ms | warm p95 ${observation.warm.p95Ms}ms\n`
+    );
+    for (const failure of comparison.failures) process.stderr.write(`performance: ${failure}\n`);
+    return 1;
+  }
+  process.stdout.write(
+    `performance: pass | ${observation.environment.class} | 300 docs | cold p95 ${observation.cold.p95Ms}ms | warm p95 ${observation.warm.p95Ms}ms\n`
+  );
+  return 0;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === THIS_FILE) {
+  main().then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (error) => {
+      process.stderr.write(`performance: ${error.message}\n`);
+      process.exitCode = 1;
+    }
+  );
+}
+
+export {
+  comparePerformance,
+  generateCorpus,
+  ruleSetMetadata
+};

--- a/scripts/run-corpus.mjs
+++ b/scripts/run-corpus.mjs
@@ -6,6 +6,8 @@ import { isMarkdownPath } from '../src/markdown-files.mjs';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
+const THIS_FILE = fileURLToPath(import.meta.url);
+const REPOSITORY_ROOT = path.resolve(path.dirname(THIS_FILE), '..');
 const DEFAULT_MANIFEST = 'bench/corpus.manifest.json';
 const DEFAULT_REPEAT = 1;
 const DEFAULT_CACHE_ROOT = path.join('.cache', 'corpus');
@@ -409,7 +411,7 @@ async function runCorpus(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   const manifestPath = path.resolve(args.manifest);
   const outPath = path.resolve(args.out);
-  const cliPath = path.resolve('src/index.mjs');
+  const cliPath = path.join(REPOSITORY_ROOT, 'src', 'index.mjs');
 
   if (!fs.existsSync(cliPath)) {
     throw new Error(`Cannot find doclify CLI entrypoint: ${cliPath}`);
@@ -512,7 +514,6 @@ async function runCorpus(argv = process.argv.slice(2)) {
   return hasCrashes ? 1 : 0;
 }
 
-const THIS_FILE = fileURLToPath(import.meta.url);
 if (process.argv[1] && path.resolve(process.argv[1]) === THIS_FILE) {
   runCorpus().then(
     (code) => process.exit(code),

--- a/scripts/test-isolation.mjs
+++ b/scripts/test-isolation.mjs
@@ -63,6 +63,8 @@ function snapshotTree(root) {
 
 function captureGitStatus(root) {
   const result = spawnSync('git', [
+    '-c',
+    'core.fsmonitor=false',
     '-C',
     path.resolve(root),
     'status',

--- a/scripts/test-isolation.mjs
+++ b/scripts/test-isolation.mjs
@@ -1,0 +1,243 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const SANDBOX_PREFIX = 'doclify-test-run-';
+const STALE_SANDBOX_MS = 6 * 60 * 60 * 1000;
+
+function portablePath(value) {
+  return value.split(path.sep).join('/');
+}
+
+function entryKind(stat) {
+  if (stat.isDirectory()) return 'directory';
+  if (stat.isFile()) return 'file';
+  if (stat.isSymbolicLink()) return 'symlink';
+  return 'other';
+}
+
+function snapshotTree(root) {
+  const resolvedRoot = path.resolve(root);
+  const entries = [];
+  const pending = [resolvedRoot];
+
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    let children;
+    try {
+      children = fs.readdirSync(directory, { withFileTypes: true })
+        .sort((left, right) => left.name.localeCompare(right.name, 'en'));
+    } catch (error) {
+      const relative = portablePath(path.relative(resolvedRoot, directory)) || '.';
+      throw new Error(`Cannot inspect repository path ${JSON.stringify(relative)} (${error.code || 'UNKNOWN'}).`);
+    }
+    for (const child of children) {
+      if (directory === resolvedRoot && child.name === '.git') continue;
+      const absolute = path.join(directory, child.name);
+      const relative = portablePath(path.relative(resolvedRoot, absolute));
+      let stat;
+      try {
+        stat = fs.lstatSync(absolute, { bigint: true });
+      } catch (error) {
+        throw new Error(`Cannot inspect repository path ${JSON.stringify(relative)} (${error.code || 'UNKNOWN'}).`);
+      }
+      const kind = entryKind(stat);
+      entries.push({
+        path: relative,
+        kind,
+        mode: Number(stat.mode),
+        size: stat.size.toString(),
+        mtimeNs: stat.mtimeNs.toString(),
+        ctimeNs: stat.ctimeNs.toString()
+      });
+      if (kind === 'directory') pending.push(absolute);
+    }
+  }
+
+  entries.sort((left, right) => left.path.localeCompare(right.path, 'en'));
+  const fingerprint = crypto.createHash('sha256').update(JSON.stringify(entries)).digest('hex');
+  return { entries, fingerprint };
+}
+
+function captureGitStatus(root) {
+  const result = spawnSync('git', [
+    '-C',
+    path.resolve(root),
+    'status',
+    '--porcelain=v1',
+    '-z',
+    '--untracked-files=all',
+    '--ignored=matching'
+  ], {
+    encoding: 'utf8',
+    env: {
+      PATH: process.env.PATH || '',
+      LANG: 'C',
+      LC_ALL: 'C',
+      GIT_CONFIG_GLOBAL: process.platform === 'win32' ? 'NUL' : '/dev/null',
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_TERMINAL_PROMPT: '0'
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error('Unable to capture repository status for the test-isolation guard.');
+  }
+  return result.stdout;
+}
+
+function captureRepositoryState(root) {
+  return {
+    gitStatus: captureGitStatus(root),
+    tree: snapshotTree(root)
+  };
+}
+
+function describeTreeChanges(beforeEntries, afterEntries, limit = 12) {
+  const before = new Map(beforeEntries.map((entry) => [entry.path, entry]));
+  const after = new Map(afterEntries.map((entry) => [entry.path, entry]));
+  const paths = [...new Set([...before.keys(), ...after.keys()])].sort((left, right) => left.localeCompare(right, 'en'));
+  const changes = [];
+
+  for (const entryPath of paths) {
+    const previous = before.get(entryPath);
+    const current = after.get(entryPath);
+    if (!previous) {
+      changes.push(`added ${JSON.stringify(entryPath)}`);
+    } else if (!current) {
+      changes.push(`removed ${JSON.stringify(entryPath)}`);
+    } else {
+      const structuralKeys = ['kind', 'mode', 'size'];
+      const structural = structuralKeys.some((key) => previous[key] !== current[key]);
+      if (structural) {
+        changes.push(`size, type, or mode changed ${JSON.stringify(entryPath)}`);
+      } else if (previous.mtimeNs !== current.mtimeNs || previous.ctimeNs !== current.ctimeNs) {
+        changes.push(`timestamps changed ${JSON.stringify(entryPath)}`);
+      }
+    }
+    if (changes.length >= limit) break;
+  }
+  return changes;
+}
+
+function compareRepositoryStates(before, after) {
+  const gitStatusChanged = before.gitStatus !== after.gitStatus;
+  const treeChanged = before.tree.fingerprint !== after.tree.fingerprint;
+  return {
+    unchanged: !gitStatusChanged && !treeChanged,
+    gitStatusChanged,
+    treeChanged,
+    changes: treeChanged ? describeTreeChanges(before.tree.entries, after.tree.entries) : []
+  };
+}
+
+function cleanupStaleSandboxes(baseDirectory = os.tmpdir(), options = {}) {
+  const prefix = options.prefix || SANDBOX_PREFIX;
+  const olderThanMs = options.olderThanMs ?? STALE_SANDBOX_MS;
+  const now = options.now ?? Date.now();
+  const removed = [];
+  let entries = [];
+  try {
+    entries = fs.readdirSync(baseDirectory, { withFileTypes: true });
+  } catch {
+    return removed;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith(prefix)) continue;
+    const candidate = path.join(baseDirectory, entry.name);
+    let stat;
+    try {
+      stat = fs.lstatSync(candidate);
+    } catch {
+      continue;
+    }
+    if (now - stat.mtimeMs <= olderThanMs) continue;
+    try {
+      fs.rmSync(candidate, { recursive: true, force: true });
+      removed.push(candidate);
+    } catch {
+      // Stale cleanup is best-effort; the new run gets its own unique sandbox.
+    }
+  }
+  return removed;
+}
+
+function createSandbox(options = {}) {
+  const baseDirectory = path.resolve(options.baseDirectory || os.tmpdir());
+  const prefix = options.prefix || SANDBOX_PREFIX;
+  cleanupStaleSandboxes(baseDirectory, { prefix });
+  return fs.mkdtempSync(path.join(baseDirectory, prefix));
+}
+
+function createIsolatedEnvironment(sandbox) {
+  const resolvedSandbox = path.resolve(sandbox);
+  const doclifyHome = path.join(resolvedSandbox, 'doclify-home');
+  const cacheHome = path.join(resolvedSandbox, 'cache-home');
+  const configHome = path.join(resolvedSandbox, 'config-home');
+  fs.mkdirSync(doclifyHome, { recursive: true });
+  fs.mkdirSync(cacheHome, { recursive: true });
+  fs.mkdirSync(configHome, { recursive: true });
+
+  const environment = {
+    PATH: process.env.PATH || '',
+    LANG: 'C',
+    LC_ALL: 'C',
+    TZ: 'UTC',
+    NO_COLOR: '1',
+    TMPDIR: resolvedSandbox,
+    TMP: resolvedSandbox,
+    TEMP: resolvedSandbox,
+    XDG_CACHE_HOME: cacheHome,
+    XDG_CONFIG_HOME: configHome,
+    DOCLIFY_HOME: doclifyHome,
+    DOCLIFY_TEST_SANDBOX: resolvedSandbox,
+    GIT_CONFIG_GLOBAL: path.join(configHome, 'gitconfig'),
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_TERMINAL_PROMPT: '0'
+  };
+  if (process.env.CI === 'true') environment.CI = 'true';
+  return environment;
+}
+
+function removeSandbox(sandbox) {
+  fs.rmSync(path.resolve(sandbox), { recursive: true, force: true });
+}
+
+function installCleanupHandlers(cleanup) {
+  let cleaned = false;
+  const runCleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    cleanup();
+  };
+  const onSigint = () => {
+    runCleanup();
+    process.exit(130);
+  };
+  const onSigterm = () => {
+    runCleanup();
+    process.exit(143);
+  };
+  process.once('SIGINT', onSigint);
+  process.once('SIGTERM', onSigterm);
+  process.once('exit', runCleanup);
+  return () => {
+    process.removeListener('SIGINT', onSigint);
+    process.removeListener('SIGTERM', onSigterm);
+    process.removeListener('exit', runCleanup);
+  };
+}
+
+export {
+  captureRepositoryState,
+  cleanupStaleSandboxes,
+  compareRepositoryStates,
+  createIsolatedEnvironment,
+  createSandbox,
+  installCleanupHandlers,
+  removeSandbox,
+  snapshotTree
+};

--- a/src/api.mjs
+++ b/src/api.mjs
@@ -1,7 +1,12 @@
 /**
  * Doclify Guardrail — Programmatic API
  *
- * Usage:
+ * V2 contract (implemented for explicit check/changed consumers):
+ *   import { check } from 'doclify-guardrail/api';
+ *
+ *   const result = await check({ paths: ['README.md'] });
+ *
+ * Legacy v1 contract (retained until its documented removal task):
  *   import { lint, fix, score } from 'doclify-guardrail/api';
  *
  *   const result = lint('# Hello\n\nWorld\n');
@@ -12,6 +17,7 @@
 import { checkMarkdown, RULE_CATALOG } from './checker.mjs';
 import { autoFixInsecureLinks, autoFixFormatting } from './fixer.mjs';
 import { computeDocHealthScore } from './quality.mjs';
+import { check } from './core.mjs';
 
 /**
  * Lint a Markdown string and return findings.
@@ -99,4 +105,4 @@ function score(counts) {
   return computeDocHealthScore(counts);
 }
 
-export { lint, fix, score, RULE_CATALOG };
+export { check, lint, fix, score, RULE_CATALOG };

--- a/src/config-v2.mjs
+++ b/src/config-v2.mjs
@@ -1,0 +1,286 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { isDescendantOrSame } from './workspace-path.mjs';
+
+const CONFIG_NAME = '.doclify-guardrail.json';
+const ALLOWED_KEYS = new Set([
+  'ignoreRules',
+  'exclude',
+  'siteRoot',
+  'linkAllowList',
+  'linkTimeoutMs',
+  'linkConcurrency'
+]);
+const REMOVED_KEYS = new Set([
+  'strict',
+  'maxLineLength',
+  'checkLinks',
+  'checkFreshness',
+  'freshnessMaxDays',
+  'checkFrontmatter',
+  'checkInlineHtml',
+  'push',
+  'projectId'
+]);
+const OPTIONAL_CONFIG_UNAVAILABLE_CODES = new Set(['EACCES', 'EPERM', 'ENOTDIR']);
+
+class ConfigV2Error extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'ConfigV2Error';
+    this.code = code;
+  }
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function canonicalDirectory(directory) {
+  const resolved = path.resolve(directory);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function isLexicallyContained(candidate, boundary) {
+  const relative = path.relative(path.resolve(boundary), path.resolve(candidate));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function assertStringArray(value, key, configPath) {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string' || item.trim() === '')) {
+    throw new ConfigV2Error('config-invalid', `${key} in ${configPath} must be an array of non-empty strings.`);
+  }
+}
+
+function assertPositiveInteger(value, key, configPath) {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new ConfigV2Error('config-invalid', `${key} in ${configPath} must be a positive integer.`);
+  }
+}
+
+function readConfig(configPath, boundary, required) {
+  let stat;
+  try {
+    stat = fs.lstatSync(configPath);
+  } catch (error) {
+    if (!required && error?.code === 'ENOENT') return null;
+    if (!required && OPTIONAL_CONFIG_UNAVAILABLE_CODES.has(error?.code)) return null;
+    if (required && error?.code === 'ENOENT') {
+      throw new ConfigV2Error('config-not-found', `Configuration file not found: ${configPath}`);
+    }
+    throw new ConfigV2Error('config-invalid', `Configuration file cannot be inspected: ${configPath}`);
+  }
+
+  if (!stat.isFile() && !stat.isSymbolicLink()) {
+    throw new ConfigV2Error('config-invalid', `Configuration path must be a JSON file: ${configPath}`);
+  }
+  if (!isDescendantOrSame(configPath, boundary)) {
+    throw new ConfigV2Error('config-outside-workspace', 'Configuration file must stay inside its discovery boundary.');
+  }
+
+  let raw;
+  try {
+    raw = fs.readFileSync(configPath, 'utf8');
+  } catch {
+    throw new ConfigV2Error('config-invalid', `Configuration file cannot be read: ${configPath}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new ConfigV2Error('config-invalid', `Configuration file is not valid JSON: ${configPath}`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new ConfigV2Error('config-invalid', `Configuration file must contain a JSON object: ${configPath}`);
+  }
+
+  for (const key of Object.keys(parsed)) {
+    if (REMOVED_KEYS.has(key)) {
+      throw new ConfigV2Error('config-removed-key', `Configuration key removed in v2: ${key}`);
+    }
+    if (!ALLOWED_KEYS.has(key)) {
+      throw new ConfigV2Error('config-unknown-key', `Unknown v2 configuration key: ${key}`);
+    }
+  }
+
+  if (Object.hasOwn(parsed, 'ignoreRules')) assertStringArray(parsed.ignoreRules, 'ignoreRules', configPath);
+  if (Object.hasOwn(parsed, 'exclude')) assertStringArray(parsed.exclude, 'exclude', configPath);
+  if (Object.hasOwn(parsed, 'linkAllowList')) assertStringArray(parsed.linkAllowList, 'linkAllowList', configPath);
+  if (Object.hasOwn(parsed, 'siteRoot') && parsed.siteRoot !== null
+    && (typeof parsed.siteRoot !== 'string' || parsed.siteRoot.trim() === '')) {
+    throw new ConfigV2Error('config-invalid', `siteRoot in ${configPath} must be a non-empty string or null.`);
+  }
+  if (Object.hasOwn(parsed, 'linkTimeoutMs')) assertPositiveInteger(parsed.linkTimeoutMs, 'linkTimeoutMs', configPath);
+  if (Object.hasOwn(parsed, 'linkConcurrency')) assertPositiveInteger(parsed.linkConcurrency, 'linkConcurrency', configPath);
+
+  return parsed;
+}
+
+function normalizeExclusions(patterns, baseDir, boundary, errorCode) {
+  return patterns.map((rawPattern) => {
+    const pattern = rawPattern.replaceAll('\\', '/').replace(/^\.\//, '').replace(/\/$/, '');
+    const prefix = pattern.split('*', 1)[0] || '.';
+    const anchor = path.resolve(baseDir, prefix);
+    if (!isLexicallyContained(anchor, boundary)) {
+      throw new ConfigV2Error(errorCode, 'Exclude patterns must stay inside their resolution boundary.');
+    }
+    return { baseDir, pattern };
+  });
+}
+
+function emptyConfig() {
+  return {
+    ignoreRules: [],
+    exclusions: [],
+    siteRoot: null,
+    externalLinks: false,
+    linkAllowList: [],
+    linkTimeoutMs: null,
+    linkConcurrency: null
+  };
+}
+
+function mergeLayer(current, layer, configPath, boundary) {
+  const baseDir = path.dirname(configPath);
+  const next = {
+    ...current,
+    ignoreRules: [...current.ignoreRules],
+    exclusions: [...current.exclusions],
+    linkAllowList: [...current.linkAllowList]
+  };
+
+  if (Object.hasOwn(layer, 'ignoreRules')) next.ignoreRules.push(...layer.ignoreRules);
+  if (Object.hasOwn(layer, 'exclude')) {
+    next.exclusions.push(...normalizeExclusions(layer.exclude, baseDir, boundary, 'config-outside-workspace'));
+  }
+  if (Object.hasOwn(layer, 'linkAllowList')) next.linkAllowList.push(...layer.linkAllowList);
+  if (Object.hasOwn(layer, 'siteRoot')) {
+    next.siteRoot = layer.siteRoot == null ? null : path.resolve(baseDir, layer.siteRoot);
+  }
+  if (Object.hasOwn(layer, 'linkTimeoutMs')) next.linkTimeoutMs = layer.linkTimeoutMs;
+  if (Object.hasOwn(layer, 'linkConcurrency')) next.linkConcurrency = layer.linkConcurrency;
+  return next;
+}
+
+function mergeOverrides(current, overrides, workspace) {
+  const next = {
+    ...current,
+    ignoreRules: unique([...current.ignoreRules, ...(overrides.ignoreRules || [])]),
+    exclusions: [...current.exclusions],
+    linkAllowList: unique([...current.linkAllowList, ...(overrides.links?.allowList || [])])
+  };
+  if (overrides.exclude?.length > 0) {
+    next.exclusions.push(...normalizeExclusions(overrides.exclude, workspace, workspace, 'invalid-exclude'));
+  }
+  if (Object.hasOwn(overrides, 'siteRoot')) {
+    next.siteRoot = overrides.siteRoot == null ? null : path.resolve(workspace, overrides.siteRoot);
+  }
+  if (Object.hasOwn(overrides, 'externalLinks')) next.externalLinks = overrides.externalLinks;
+  if (overrides.links?.timeoutMs != null) next.linkTimeoutMs = overrides.links.timeoutMs;
+  if (overrides.links?.concurrency != null) next.linkConcurrency = overrides.links.concurrency;
+  next.exclusions = unique(next.exclusions.map(({ baseDir, pattern }) => `${baseDir}\0${pattern}`))
+    .map((value) => {
+      const separator = value.indexOf('\0');
+      return { baseDir: value.slice(0, separator), pattern: value.slice(separator + 1) };
+    });
+  return next;
+}
+
+function wildcardPattern(pattern) {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '\u0000')
+    .replace(/\*/g, '[^/]*')
+    .replace(/\u0000/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+function matchesExclusion(candidate, exclusion) {
+  const parent = canonicalDirectory(path.dirname(candidate));
+  const comparableCandidate = path.join(parent, path.basename(candidate));
+  const relative = path.relative(exclusion.baseDir, comparableCandidate).split(path.sep).join('/');
+  if (relative.startsWith('..') || path.isAbsolute(relative)) return false;
+  const pattern = exclusion.pattern;
+  if (!pattern || pattern === '.') return pattern === '.' && relative === '';
+  if (pattern.includes('*')) return wildcardPattern(pattern).test(relative);
+  return relative === pattern || relative.startsWith(`${pattern}/`);
+}
+
+function createV2ConfigResolver(options) {
+  const workspace = canonicalDirectory(options.workspace);
+  const discoveryRoot = canonicalDirectory(options.discoveryRoot || workspace);
+  const overrides = options.overrides || {};
+  const directoryCache = new Map();
+  const fileCache = new Map();
+  let explicitConfig = null;
+
+  if (options.config != null) {
+    if (typeof options.config !== 'string' || options.config.trim() === '') {
+      throw new ConfigV2Error('config-invalid', 'config must be a non-empty path.');
+    }
+    const configPath = path.resolve(options.configBase || workspace, options.config);
+    if (!isDescendantOrSame(configPath, discoveryRoot)) {
+      throw new ConfigV2Error('config-outside-workspace', 'Explicit configuration must stay inside the repository or workspace boundary.');
+    }
+    const parsed = readConfig(configPath, discoveryRoot, true);
+    explicitConfig = mergeLayer(emptyConfig(), parsed, configPath, discoveryRoot);
+  }
+
+  function readLayer(configPath) {
+    if (fileCache.has(configPath)) return fileCache.get(configPath);
+    const parsed = readConfig(configPath, discoveryRoot, false);
+    fileCache.set(configPath, parsed);
+    return parsed;
+  }
+
+  function resolveDirectory(rawDirectory) {
+    if (explicitConfig) return explicitConfig;
+    const directory = canonicalDirectory(rawDirectory);
+    if (!isDescendantOrSame(directory, discoveryRoot)) return emptyConfig();
+    if (directoryCache.has(directory)) return directoryCache.get(directory);
+
+    let resolved;
+    if (directory === discoveryRoot) {
+      resolved = emptyConfig();
+    } else {
+      resolved = resolveDirectory(path.dirname(directory));
+    }
+    const configPath = path.join(directory, CONFIG_NAME);
+    const layer = readLayer(configPath);
+    if (layer) resolved = mergeLayer(resolved, layer, configPath, discoveryRoot);
+    directoryCache.set(directory, resolved);
+    return resolved;
+  }
+
+  function forPath(targetPath, optionsForPath = {}) {
+    const directory = optionsForPath.directory === true ? targetPath : path.dirname(targetPath);
+    return mergeOverrides(resolveDirectory(directory), overrides, workspace);
+  }
+
+  function isExcluded(targetPath, optionsForPath = {}) {
+    let resolved;
+    if (optionsForPath.directory === true && !explicitConfig) {
+      const directory = canonicalDirectory(targetPath);
+      if (directory === discoveryRoot) return false;
+      resolved = mergeOverrides(resolveDirectory(path.dirname(directory)), overrides, workspace);
+    } else {
+      resolved = forPath(targetPath, optionsForPath);
+    }
+    return resolved.exclusions.some((exclusion) => matchesExclusion(targetPath, exclusion));
+  }
+
+  return {
+    forPath,
+    isExcluded
+  };
+}
+
+export {
+  ConfigV2Error,
+  createV2ConfigResolver
+};

--- a/src/core.mjs
+++ b/src/core.mjs
@@ -3,11 +3,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { RULE_CATALOG } from './checker.mjs';
+import { ConfigV2Error, createV2ConfigResolver } from './config-v2.mjs';
+import { discoverGitRoot, getChangedFilesFromRoot, GitSelectionError } from './diff.mjs';
 import { checkWithLegacyEngine } from './legacy-adapter.mjs';
 import { checkDeadLinksDetailed } from './links.mjs';
 import { createResult } from './result.mjs';
 import { TargetSelectionError, relativePath, selectTargets } from './target-selector.mjs';
-import { isDescendantOrSame } from './workspace-path.mjs';
+import { getReadContainment, isDescendantOrSame } from './workspace-path.mjs';
 
 const SOURCE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const PACKAGE = JSON.parse(fs.readFileSync(path.join(SOURCE_DIR, '..', 'package.json'), 'utf8'));
@@ -34,8 +36,10 @@ function validateOptions(options) {
   }
   const knownOptions = new Set([
     'command',
+    'changed',
     'paths',
     'cwd',
+    'config',
     'ignoreRules',
     'exclude',
     'siteRoot',
@@ -55,6 +59,18 @@ function validateOptions(options) {
   }
   if (options.command != null && !['check', 'changed'].includes(options.command)) {
     throw new DoclifyUsageError('invalid-command', 'command must be check or changed.');
+  }
+  if (options.config != null && (typeof options.config !== 'string' || options.config.trim() === '')) {
+    throw new DoclifyUsageError('config-invalid', 'config must be a non-empty path.');
+  }
+  if (options.changed != null && (typeof options.changed !== 'object' || Array.isArray(options.changed))) {
+    throw new DoclifyUsageError('invalid-changed-selector', 'changed must be a selector object.');
+  }
+  if (options.changed) {
+    const unknownChangedOption = Object.keys(options.changed).find((key) => !['base', 'staged'].includes(key));
+    if (unknownChangedOption) {
+      throw new DoclifyUsageError('invalid-changed-selector', `Unknown changed selector: ${unknownChangedOption}.`);
+    }
   }
   if (options.ignoreRules != null && !Array.isArray(options.ignoreRules)) {
     throw new DoclifyUsageError('invalid-ignore-rules', 'ignoreRules must be an array.');
@@ -80,7 +96,12 @@ function validateOptions(options) {
   if (options.links?.allowList != null && (!Array.isArray(options.links.allowList) || options.links.allowList.some((item) => typeof item !== 'string'))) {
     throw new DoclifyUsageError('invalid-link-allow-list', 'links.allowList must be an array of strings.');
   }
-  if (options.externalLinks !== true && (options.links?.allowList?.length > 0 || options.links?.timeoutMs != null || options.links?.concurrency != null)) {
+  const unknownLinkOption = options.links && Object.keys(options.links).find((key) => !['allowList', 'timeoutMs', 'concurrency'].includes(key));
+  if (unknownLinkOption) {
+    throw new DoclifyUsageError('invalid-links', `Unknown links option: ${unknownLinkOption}.`);
+  }
+  if (options.externalLinks !== true
+    && (options.links?.allowList?.length > 0 || options.links?.timeoutMs != null || options.links?.concurrency != null)) {
     throw new DoclifyUsageError('invalid-link-options', 'Remote link options require externalLinks: true.');
   }
   assertPositiveInteger(options.links?.timeoutMs, 'links.timeoutMs');
@@ -104,6 +125,54 @@ function stableReadDiagnostic(filePath, workspace, error) {
   };
 }
 
+function changedSelector(options) {
+  if (options.command !== 'changed') {
+    if (options.changed != null) {
+      throw new DoclifyUsageError('invalid-changed-selector', 'changed selectors require command: changed.');
+    }
+    return null;
+  }
+  if (options.paths != null && options.paths.length > 0) {
+    throw new DoclifyUsageError('unexpected-target', 'changed does not accept paths.');
+  }
+  const selector = options.changed || {};
+  if (Object.hasOwn(selector, 'base') && (typeof selector.base !== 'string' || selector.base.length === 0)) {
+    throw new DoclifyUsageError('invalid-changed-selector', 'changed.base must be a non-empty string.');
+  }
+  const hasBase = typeof selector.base === 'string' && selector.base.length > 0;
+  const hasStaged = selector.staged === true;
+  if (Number(hasBase) + Number(hasStaged) !== 1 || (Object.hasOwn(selector, 'staged') && selector.staged !== true)) {
+    throw new DoclifyUsageError('invalid-changed-selector', 'changed requires exactly one of base or staged.');
+  }
+  return selector;
+}
+
+function configOverrides(options) {
+  const overrides = {
+    ignoreRules: options.ignoreRules || [],
+    exclude: options.exclude || [],
+    links: options.links || {}
+  };
+  if (Object.hasOwn(options, 'siteRoot')) overrides.siteRoot = options.siteRoot;
+  if (Object.hasOwn(options, 'externalLinks')) overrides.externalLinks = options.externalLinks;
+  return overrides;
+}
+
+function validateResolvedOptions(options, readBoundary) {
+  validateRuleIds(options.ignoreRules);
+  if (options.siteRoot && !isDescendantOrSame(options.siteRoot, readBoundary)) {
+    throw new DoclifyUsageError('site-root-outside-workspace', 'siteRoot must stay inside the repository or workspace boundary.');
+  }
+}
+
+function asUsageError(error) {
+  if (error instanceof DoclifyUsageError) return error;
+  if (error instanceof ConfigV2Error || error instanceof GitSelectionError) {
+    return new DoclifyUsageError(error.code, error.message);
+  }
+  return error;
+}
+
 /**
  * Scan Markdown paths and return the deterministic schemaVersion 3 result.
  * Partial scans resolve with status "incomplete". Invalid usage, invalid
@@ -111,8 +180,10 @@ function stableReadDiagnostic(filePath, workspace, error) {
  *
  * @param {object} [options]
  * @param {'check'|'changed'} [options.command='check'] Result command label.
- * @param {string[]} [options.paths=['.']] Paths relative to cwd or contained absolute paths.
+ * @param {string[]} [options.paths=['.']] Paths relative to cwd or contained absolute paths for check.
  * @param {string} [options.cwd=process.cwd()] Selected workspace.
+ * @param {{base?: string, staged?: true}} [options.changed] Selector required by command changed.
+ * @param {string} [options.config] One explicit v2 config file; disables automatic hierarchy.
  * @param {string[]} [options.ignoreRules=[]] Known rule ids to suppress.
  * @param {string[]} [options.exclude=[]] Workspace-relative exclusions.
  * @param {string} [options.siteRoot] Root for root-relative local links.
@@ -122,12 +193,17 @@ function stableReadDiagnostic(filePath, workspace, error) {
  * @returns {Promise<object>}
  */
 async function check(options = {}) {
+  return (await runCheck(options)).result;
+}
+
+async function runCheck(options = {}) {
   validateOptions(options);
   const command = options.command === 'changed' ? 'changed' : 'check';
-  const cwd = path.resolve(options.cwd || process.cwd());
+  const selector = changedSelector({ ...options, command });
+  const invocationCwd = path.resolve(options.cwd || process.cwd());
   let cwdStat;
   try {
-    cwdStat = fs.statSync(cwd);
+    cwdStat = fs.statSync(invocationCwd);
   } catch {
     throw new DoclifyUsageError('workspace-unreadable', 'Workspace does not exist or cannot be inspected.');
   }
@@ -137,19 +213,55 @@ async function check(options = {}) {
 
   const ignoreRules = [...new Set(options.ignoreRules || [])];
   validateRuleIds(ignoreRules);
-  const siteRoot = options.siteRoot == null ? null : path.resolve(cwd, options.siteRoot);
-  if (siteRoot && !isDescendantOrSame(siteRoot, cwd)) {
-    throw new DoclifyUsageError('site-root-outside-workspace', 'siteRoot must stay inside the workspace.');
+
+  let gitRoot;
+  try {
+    gitRoot = discoverGitRoot(invocationCwd, { required: command === 'changed' });
+  } catch (error) {
+    throw asUsageError(error);
+  }
+  const workspace = command === 'changed' ? gitRoot : invocationCwd;
+  const discoveryRoot = gitRoot || workspace;
+
+  let selectedPaths = options.paths;
+  if (command === 'changed') {
+    try {
+      selectedPaths = getChangedFilesFromRoot(gitRoot, {
+        base: selector.base || 'HEAD',
+        staged: selector.staged === true,
+        markdownOnly: true
+      }).map((entry) => entry.path);
+    } catch (error) {
+      throw asUsageError(error);
+    }
+  }
+
+  let configResolver;
+  try {
+    configResolver = createV2ConfigResolver({
+      workspace,
+      discoveryRoot,
+      config: options.config,
+      configBase: invocationCwd,
+      overrides: configOverrides({ ...options, ignoreRules })
+    });
+    validateResolvedOptions(configResolver.forPath(workspace, { directory: true }), discoveryRoot);
+  } catch (error) {
+    throw asUsageError(error);
   }
 
   let selection;
   try {
-    selection = selectTargets({ cwd, paths: options.paths, exclude: options.exclude });
+    selection = selectTargets({
+      cwd: workspace,
+      paths: selectedPaths,
+      isExcluded: configResolver.isExcluded
+    });
   } catch (error) {
     if (error instanceof TargetSelectionError) {
       throw new DoclifyUsageError(error.code, error.message);
     }
-    throw error;
+    throw asUsageError(error);
   }
 
   const files = [];
@@ -162,6 +274,23 @@ async function check(options = {}) {
       throw new DoclifyUsageError('aborted', 'Scan was aborted.');
     }
     const filePath = relativePath(absolutePath, selection.workspace);
+    if (getReadContainment(absolutePath, workspace) === 'outside') {
+      files.push({ path: filePath, scanned: false, findings: null, suppressions: [] });
+      diagnostics.push({
+        code: 'target-outside-workspace',
+        severity: 'error',
+        path: filePath,
+        message: 'Target resolved outside the workspace before it could be read.'
+      });
+      continue;
+    }
+    let fileOptions;
+    try {
+      fileOptions = configResolver.forPath(absolutePath);
+      validateResolvedOptions(fileOptions, discoveryRoot);
+    } catch (error) {
+      throw asUsageError(error);
+    }
     let content;
     try {
       content = fs.readFileSync(absolutePath, 'utf8');
@@ -174,19 +303,19 @@ async function check(options = {}) {
     const adapted = checkWithLegacyEngine(content, {
       path: filePath,
       absolutePath,
-      ignoreRules
+      ignoreRules: fileOptions.ignoreRules
     });
 
     const linkResult = await checkDeadLinksDetailed(content, {
       sourceFile: absolutePath,
-      siteRoot,
-      linkAllowList: options.links?.allowList || [],
-      timeoutMs: options.links?.timeoutMs,
-      concurrency: options.links?.concurrency,
+      siteRoot: fileOptions.siteRoot,
+      linkAllowList: fileOptions.linkAllowList,
+      timeoutMs: fileOptions.linkTimeoutMs || undefined,
+      concurrency: fileOptions.linkConcurrency || undefined,
       remoteCache,
-      checkRemote: options.externalLinks === true
+      checkRemote: fileOptions.externalLinks === true
     });
-    const ignored = new Set(ignoreRules);
+    const ignored = new Set(fileOptions.ignoreRules);
     for (const finding of linkResult.findings) {
       if (ignored.has(finding.code)) continue;
       adapted.findings.push({
@@ -210,13 +339,16 @@ async function check(options = {}) {
     throw new DoclifyUsageError('scan-failed', 'No selected Markdown files could be scanned.');
   }
 
-  return createResult({
-    toolVersion: PACKAGE.version,
-    command,
-    files,
-    findings,
-    diagnostics
-  });
+  return {
+    workspace,
+    result: createResult({
+      toolVersion: PACKAGE.version,
+      command,
+      files,
+      findings,
+      diagnostics
+    })
+  };
 }
 
-export { DoclifyUsageError, check };
+export { DoclifyUsageError, check, runCheck };

--- a/src/core.mjs
+++ b/src/core.mjs
@@ -1,0 +1,222 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { RULE_CATALOG } from './checker.mjs';
+import { checkWithLegacyEngine } from './legacy-adapter.mjs';
+import { checkDeadLinksDetailed } from './links.mjs';
+import { createResult } from './result.mjs';
+import { TargetSelectionError, relativePath, selectTargets } from './target-selector.mjs';
+import { isDescendantOrSame } from './workspace-path.mjs';
+
+const SOURCE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE = JSON.parse(fs.readFileSync(path.join(SOURCE_DIR, '..', 'package.json'), 'utf8'));
+const KNOWN_RULE_IDS = new Set(RULE_CATALOG.map((rule) => rule.id));
+
+class DoclifyUsageError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'DoclifyUsageError';
+    this.code = code;
+  }
+}
+
+function assertPositiveInteger(value, label) {
+  if (value == null) return;
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new DoclifyUsageError('invalid-option', `${label} must be a positive integer.`);
+  }
+}
+
+function validateOptions(options) {
+  if (!options || typeof options !== 'object' || Array.isArray(options)) {
+    throw new DoclifyUsageError('invalid-options', 'check options must be an object.');
+  }
+  const knownOptions = new Set([
+    'command',
+    'paths',
+    'cwd',
+    'ignoreRules',
+    'exclude',
+    'siteRoot',
+    'externalLinks',
+    'links',
+    'signal'
+  ]);
+  const unknownOption = Object.keys(options).find((key) => !knownOptions.has(key));
+  if (unknownOption) {
+    throw new DoclifyUsageError('unknown-option', `Unknown check option: ${unknownOption}.`);
+  }
+  if (options.cwd != null && typeof options.cwd !== 'string') {
+    throw new DoclifyUsageError('invalid-workspace', 'cwd must be a string.');
+  }
+  if (options.paths != null && (!Array.isArray(options.paths) || options.paths.some((item) => typeof item !== 'string'))) {
+    throw new DoclifyUsageError('invalid-paths', 'paths must be an array of strings.');
+  }
+  if (options.command != null && !['check', 'changed'].includes(options.command)) {
+    throw new DoclifyUsageError('invalid-command', 'command must be check or changed.');
+  }
+  if (options.ignoreRules != null && !Array.isArray(options.ignoreRules)) {
+    throw new DoclifyUsageError('invalid-ignore-rules', 'ignoreRules must be an array.');
+  }
+  if (options.ignoreRules?.some((item) => typeof item !== 'string')) {
+    throw new DoclifyUsageError('invalid-ignore-rules', 'ignoreRules must contain only strings.');
+  }
+  if (options.exclude != null && !Array.isArray(options.exclude)) {
+    throw new DoclifyUsageError('invalid-exclude', 'exclude must be an array.');
+  }
+  if (options.exclude?.some((item) => typeof item !== 'string')) {
+    throw new DoclifyUsageError('invalid-exclude', 'exclude must contain only strings.');
+  }
+  if (options.siteRoot != null && typeof options.siteRoot !== 'string') {
+    throw new DoclifyUsageError('invalid-site-root', 'siteRoot must be a string.');
+  }
+  if (options.externalLinks != null && typeof options.externalLinks !== 'boolean') {
+    throw new DoclifyUsageError('invalid-external-links', 'externalLinks must be a boolean.');
+  }
+  if (options.links != null && (typeof options.links !== 'object' || Array.isArray(options.links))) {
+    throw new DoclifyUsageError('invalid-links', 'links must be an object.');
+  }
+  if (options.links?.allowList != null && (!Array.isArray(options.links.allowList) || options.links.allowList.some((item) => typeof item !== 'string'))) {
+    throw new DoclifyUsageError('invalid-link-allow-list', 'links.allowList must be an array of strings.');
+  }
+  if (options.externalLinks !== true && (options.links?.allowList?.length > 0 || options.links?.timeoutMs != null || options.links?.concurrency != null)) {
+    throw new DoclifyUsageError('invalid-link-options', 'Remote link options require externalLinks: true.');
+  }
+  assertPositiveInteger(options.links?.timeoutMs, 'links.timeoutMs');
+  assertPositiveInteger(options.links?.concurrency, 'links.concurrency');
+}
+
+function validateRuleIds(ignoreRules) {
+  for (const ruleId of ignoreRules) {
+    if (!KNOWN_RULE_IDS.has(ruleId)) {
+      throw new DoclifyUsageError('unknown-rule', `Unknown rule id: ${ruleId}`);
+    }
+  }
+}
+
+function stableReadDiagnostic(filePath, workspace, error) {
+  return {
+    code: 'file-unreadable',
+    severity: 'error',
+    path: relativePath(filePath, workspace),
+    message: `Unable to read file (${error?.code || 'UNKNOWN'}).`
+  };
+}
+
+/**
+ * Scan Markdown paths and return the deterministic schemaVersion 3 result.
+ * Partial scans resolve with status "incomplete". Invalid usage, invalid
+ * configuration, and total scan failure reject with a stable error.code.
+ *
+ * @param {object} [options]
+ * @param {'check'|'changed'} [options.command='check'] Result command label.
+ * @param {string[]} [options.paths=['.']] Paths relative to cwd or contained absolute paths.
+ * @param {string} [options.cwd=process.cwd()] Selected workspace.
+ * @param {string[]} [options.ignoreRules=[]] Known rule ids to suppress.
+ * @param {string[]} [options.exclude=[]] Workspace-relative exclusions.
+ * @param {string} [options.siteRoot] Root for root-relative local links.
+ * @param {boolean} [options.externalLinks=false] Explicit network opt-in.
+ * @param {{allowList?: string[], timeoutMs?: number, concurrency?: number}} [options.links]
+ * @param {AbortSignal} [options.signal]
+ * @returns {Promise<object>}
+ */
+async function check(options = {}) {
+  validateOptions(options);
+  const command = options.command === 'changed' ? 'changed' : 'check';
+  const cwd = path.resolve(options.cwd || process.cwd());
+  let cwdStat;
+  try {
+    cwdStat = fs.statSync(cwd);
+  } catch {
+    throw new DoclifyUsageError('workspace-unreadable', 'Workspace does not exist or cannot be inspected.');
+  }
+  if (!cwdStat.isDirectory()) {
+    throw new DoclifyUsageError('workspace-invalid', 'Workspace must be a directory.');
+  }
+
+  const ignoreRules = [...new Set(options.ignoreRules || [])];
+  validateRuleIds(ignoreRules);
+  const siteRoot = options.siteRoot == null ? null : path.resolve(cwd, options.siteRoot);
+  if (siteRoot && !isDescendantOrSame(siteRoot, cwd)) {
+    throw new DoclifyUsageError('site-root-outside-workspace', 'siteRoot must stay inside the workspace.');
+  }
+
+  let selection;
+  try {
+    selection = selectTargets({ cwd, paths: options.paths, exclude: options.exclude });
+  } catch (error) {
+    if (error instanceof TargetSelectionError) {
+      throw new DoclifyUsageError(error.code, error.message);
+    }
+    throw error;
+  }
+
+  const files = [];
+  const findings = [];
+  const diagnostics = [...selection.diagnostics];
+  const remoteCache = new Map();
+
+  for (const absolutePath of selection.paths) {
+    if (options.signal?.aborted) {
+      throw new DoclifyUsageError('aborted', 'Scan was aborted.');
+    }
+    const filePath = relativePath(absolutePath, selection.workspace);
+    let content;
+    try {
+      content = fs.readFileSync(absolutePath, 'utf8');
+    } catch (error) {
+      files.push({ path: filePath, scanned: false, findings: null, suppressions: [] });
+      diagnostics.push(stableReadDiagnostic(absolutePath, selection.workspace, error));
+      continue;
+    }
+
+    const adapted = checkWithLegacyEngine(content, {
+      path: filePath,
+      absolutePath,
+      ignoreRules
+    });
+
+    const linkResult = await checkDeadLinksDetailed(content, {
+      sourceFile: absolutePath,
+      siteRoot,
+      linkAllowList: options.links?.allowList || [],
+      timeoutMs: options.links?.timeoutMs,
+      concurrency: options.links?.concurrency,
+      remoteCache,
+      checkRemote: options.externalLinks === true
+    });
+    const ignored = new Set(ignoreRules);
+    for (const finding of linkResult.findings) {
+      if (ignored.has(finding.code)) continue;
+      adapted.findings.push({
+        ruleId: String(finding.code),
+        severity: 'advisory',
+        confidence: 'unverified',
+        path: filePath,
+        line: Number.isInteger(finding.line) ? finding.line : null,
+        column: null,
+        message: String(finding.message),
+        evidence: null
+      });
+    }
+    adapted.file.findings = adapted.findings.length;
+
+    files.push(adapted.file);
+    findings.push(...adapted.findings);
+  }
+
+  if (command === 'check' && selection.paths.length === 0 && diagnostics.length === 0) {
+    throw new DoclifyUsageError('scan-failed', 'No selected Markdown files could be scanned.');
+  }
+
+  return createResult({
+    toolVersion: PACKAGE.version,
+    command,
+    files,
+    findings,
+    diagnostics
+  });
+}
+
+export { DoclifyUsageError, check };

--- a/src/core.mjs
+++ b/src/core.mjs
@@ -313,10 +313,12 @@ async function runCheck(options = {}) {
       timeoutMs: fileOptions.linkTimeoutMs || undefined,
       concurrency: fileOptions.linkConcurrency || undefined,
       remoteCache,
-      checkRemote: fileOptions.externalLinks === true
+      checkRemote: fileOptions.externalLinks === true,
+      readBoundary: discoveryRoot
     });
     const ignored = new Set(fileOptions.ignoreRules);
     for (const finding of linkResult.findings) {
+      if (finding.operational === true) continue;
       if (ignored.has(finding.code)) continue;
       adapted.findings.push({
         ruleId: String(finding.code),
@@ -327,6 +329,14 @@ async function runCheck(options = {}) {
         column: null,
         message: String(finding.message),
         evidence: null
+      });
+    }
+    for (const diagnostic of linkResult.diagnostics) {
+      diagnostics.push({
+        code: String(diagnostic.code),
+        severity: 'error',
+        path: filePath,
+        message: String(diagnostic.message)
       });
     }
     adapted.file.findings = adapted.findings.length;

--- a/src/diff.mjs
+++ b/src/diff.mjs
@@ -1,98 +1,173 @@
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
+
 import { isMarkdownPath } from './markdown-files.mjs';
 
 const FORBIDDEN_BASE_CHARS_RX = /[;|&$><`()\n\r]/;
+const NOT_A_REPOSITORY_RX = /not a git repository/i;
+const UNKNOWN_REVISION_RX = /unknown revision|bad revision|ambiguous argument|invalid object name/i;
+
+class GitSelectionError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'GitSelectionError';
+    this.code = code;
+  }
+}
+
+function gitEnvironment() {
+  return {
+    ...process.env,
+    LANG: 'C',
+    LC_ALL: 'C'
+  };
+}
+
+function runGit(cwd, args) {
+  return spawnSync('git', ['-C', cwd, ...args], {
+    encoding: 'utf8',
+    env: gitEnvironment(),
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+}
 
 function assertSafeBaseRef(base) {
   if (typeof base !== 'string' || base.length === 0 || FORBIDDEN_BASE_CHARS_RX.test(base)) {
-    throw new Error('Invalid --base value: contains forbidden shell metacharacters');
+    throw new GitSelectionError('invalid-base-ref', 'Invalid --base value: contains forbidden shell metacharacters');
   }
   if (base.startsWith('-')) {
-    throw new Error('Invalid --base value: must not start with "-"');
+    throw new GitSelectionError('invalid-base-ref', 'Invalid --base value: must not start with "-"');
   }
+}
+
+function classifySpawnFailure(result, fallbackCode = 'git-failed') {
+  if (result.error?.code === 'ENOENT') {
+    return new GitSelectionError('git-unavailable', 'Git is not available.');
+  }
+  if (result.error) {
+    return new GitSelectionError(fallbackCode, 'Git could not be executed.');
+  }
+  const stderr = String(result.stderr || '');
+  if (NOT_A_REPOSITORY_RX.test(stderr)) {
+    return new GitSelectionError('not-a-git-repository', 'The selected directory is not inside a Git repository.');
+  }
+  return new GitSelectionError(fallbackCode, 'Git changed-file discovery failed.');
+}
+
+function discoverGitRoot(cwd = process.cwd(), options = {}) {
+  const start = path.resolve(cwd);
+  const result = runGit(start, ['rev-parse', '--show-toplevel']);
+  if (result.error || result.status !== 0) {
+    if (options.required === false) return null;
+    throw classifySpawnFailure(result);
+  }
+
+  const root = String(result.stdout || '').trim();
+  if (!root) {
+    if (options.required === false) return null;
+    throw new GitSelectionError('git-failed', 'Git returned no repository root.');
+  }
+  return path.resolve(root);
 }
 
 function buildGitArgs(base = 'HEAD', staged = false) {
-  let gitArgs;
   if (staged) {
-    gitArgs = ['diff', '--cached', '--name-status', '--find-renames', '--diff-filter=ACMR'];
-  } else {
-    assertSafeBaseRef(base);
-    gitArgs = ['diff', '--name-status', '--find-renames', '--diff-filter=ACMR', base];
+    return ['diff', '--no-ext-diff', '--no-textconv', '--cached', '--name-status', '--find-renames', '--diff-filter=ACMR', '-z', '--'];
   }
-  return gitArgs;
+  assertSafeBaseRef(base);
+  return ['diff', '--no-ext-diff', '--no-textconv', '--name-status', '--find-renames', '--diff-filter=ACMR', '-z', base, '--'];
 }
 
-function parseChangedFiles(stdout, cwd) {
-  return stdout
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const parts = line.split('\t');
-      const status = parts[0];
-      if (status.startsWith('R')) {
-        const previousPath = parts[1];
-        const currentPath = parts[2];
-        return {
-          status,
-          path: path.resolve(cwd, currentPath),
-          previousPath: path.resolve(cwd, previousPath)
-        };
+function resolveGitPath(root, gitPath) {
+  const absolute = path.resolve(root, gitPath);
+  const relative = path.relative(root, absolute);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new GitSelectionError('git-failed', 'Git returned a path outside the repository root.');
+  }
+  return absolute;
+}
+
+function parseChangedFiles(stdout, root) {
+  const fields = String(stdout || '').split('\0');
+  if (fields.at(-1) === '') fields.pop();
+  const changed = [];
+
+  for (let index = 0; index < fields.length;) {
+    const status = fields[index++];
+    if (!status) {
+      throw new GitSelectionError('git-failed', 'Git returned malformed changed-file output.');
+    }
+    if (status.startsWith('R') || status.startsWith('C')) {
+      const previousPath = fields[index++];
+      const currentPath = fields[index++];
+      if (previousPath == null || currentPath == null) {
+        throw new GitSelectionError('git-failed', 'Git returned malformed rename output.');
       }
-      return {
+      changed.push({
         status,
-        path: path.resolve(cwd, parts[1] || parts[0]),
-        previousPath: null
-      };
+        path: resolveGitPath(root, currentPath),
+        previousPath: resolveGitPath(root, previousPath)
+      });
+      continue;
+    }
+
+    const currentPath = fields[index++];
+    if (currentPath == null) {
+      throw new GitSelectionError('git-failed', 'Git returned malformed changed-file output.');
+    }
+    changed.push({
+      status,
+      path: resolveGitPath(root, currentPath),
+      previousPath: null
     });
+  }
+
+  return changed;
+}
+
+function getChangedFilesFromRoot(root, opts = {}) {
+  const { base = 'HEAD', staged = false, markdownOnly = false } = opts;
+  const result = runGit(root, buildGitArgs(base, staged));
+  if (result.error || result.status !== 0) {
+    const stderr = String(result.stderr || '');
+    if (!staged && UNKNOWN_REVISION_RX.test(stderr)) {
+      throw new GitSelectionError('unknown-base-ref', `Unknown Git base ref: ${base}`);
+    }
+    throw classifySpawnFailure(result);
+  }
+
+  const changedFiles = parseChangedFiles(result.stdout, root);
+  return markdownOnly
+    ? changedFiles.filter((entry) => isMarkdownPath(entry.path))
+    : changedFiles;
 }
 
 /**
- * Get files changed in git relative to a base ref.
- * @param {object} opts
- * @param {string} [opts.base] - Base git ref (default: HEAD)
- * @param {boolean} [opts.staged] - Only staged files
- * @param {boolean} [opts.markdownOnly] - Filter to .md/.mdx files only
+ * Get files changed in Git relative to a base ref. Paths are absolute and
+ * resolved from the repository root, even when cwd is a subdirectory.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.base='HEAD']
+ * @param {boolean} [opts.staged=false]
+ * @param {boolean} [opts.markdownOnly=false]
+ * @param {string} [opts.cwd=process.cwd()]
  * @returns {{ status: string, path: string, previousPath: string | null }[]}
  */
 function getChangedFiles(opts = {}) {
-  const { base = 'HEAD', staged = false, markdownOnly = false } = opts;
-  const gitArgs = buildGitArgs(base, staged);
-
-  const result = spawnSync('git', gitArgs, {
-    encoding: 'utf8',
-    stdio: ['pipe', 'pipe', 'pipe']
-  });
-
-  if (result.error) {
-    throw new Error(`Git diff failed: ${result.error.message}`);
-  }
-
-  if (result.status !== 0) {
-    const msg = result.stderr ? result.stderr.trim() : `exit code ${result.status}`;
-    throw new Error(`Git diff failed: ${msg}`);
-  }
-
-  const cwd = process.cwd();
-  const changedFiles = parseChangedFiles(result.stdout, cwd);
-  if (!markdownOnly) {
-    return changedFiles;
-  }
-
-  return changedFiles.filter((entry) => isMarkdownPath(entry.path));
+  const base = Object.hasOwn(opts, 'base') ? opts.base : 'HEAD';
+  if (opts.staged !== true) assertSafeBaseRef(base);
+  const root = opts.gitRoot || discoverGitRoot(opts.cwd || process.cwd());
+  return getChangedFilesFromRoot(root, opts);
 }
 
-/**
- * Get Markdown/MDX files changed in git relative to a base ref.
- * @param {object} opts
- * @param {string} [opts.base] - Base git ref (default: HEAD)
- * @param {boolean} [opts.staged] - Only staged files
- * @returns {string[]} Array of absolute file paths
- */
 function getChangedMarkdownFiles(opts = {}) {
   return getChangedFiles({ ...opts, markdownOnly: true }).map((entry) => entry.path);
 }
 
-export { getChangedFiles, getChangedMarkdownFiles };
+export {
+  GitSelectionError,
+  discoverGitRoot,
+  getChangedFiles,
+  getChangedFilesFromRoot,
+  getChangedMarkdownFiles
+};

--- a/src/diff.mjs
+++ b/src/diff.mjs
@@ -19,12 +19,18 @@ function gitEnvironment() {
   return {
     ...process.env,
     LANG: 'C',
-    LC_ALL: 'C'
+    LC_ALL: 'C',
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_PAGER: 'cat'
   };
 }
 
 function runGit(cwd, args) {
-  return spawnSync('git', ['-C', cwd, ...args], {
+  // Changed-file discovery runs in the selected repository. Disable the one
+  // index extension that can execute a repository-configured command before
+  // asking Git to inspect it.
+  return spawnSync('git', ['-c', 'core.fsmonitor=false', '-C', cwd, ...args], {
     encoding: 'utf8',
     env: gitEnvironment(),
     stdio: ['ignore', 'pipe', 'pipe']

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -26,6 +26,7 @@ import {
   generateSarifReport,
   generateBadge
 } from './ci-output.mjs';
+import { isV2Command, runV2Cli } from './v2-cli.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -1555,6 +1556,9 @@ async function runScan(args, resolved, filePaths, customRules, opts = {}) {
 
 async function runCli(argv = process.argv.slice(2)) {
   const topLevel = argv[0];
+  if (isV2Command(argv)) {
+    return runV2Cli(argv);
+  }
   try {
     if (topLevel === 'login') {
       initColors(false);
@@ -2031,7 +2035,7 @@ async function runCli(argv = process.argv.slice(2)) {
 const __filename = fileURLToPath(import.meta.url);
 if (process.argv[1] && fs.realpathSync(process.argv[1]) === __filename) {
   const code = await runCli();
-  process.exit(code);
+  process.exitCode = code;
 }
 
 export { checkMarkdown, parseArgs, resolveOptions, resolveFileOptions, findParentConfigs, runCli, buildFileResult, buildOutput };

--- a/src/legacy-adapter.mjs
+++ b/src/legacy-adapter.mjs
@@ -1,0 +1,40 @@
+import { checkMarkdown } from './checker.mjs';
+import { findSuppressions } from './suppressions.mjs';
+
+function adaptFinding(finding, filePath) {
+  return {
+    ruleId: String(finding.code),
+    severity: 'advisory',
+    confidence: 'unverified',
+    path: filePath,
+    line: Number.isInteger(finding.line) ? finding.line : null,
+    column: null,
+    message: String(finding.message),
+    evidence: null
+  };
+}
+
+function checkWithLegacyEngine(content, options = {}) {
+  const ignoreRules = options.ignoreRules instanceof Set
+    ? options.ignoreRules
+    : new Set(options.ignoreRules || []);
+  const analysis = checkMarkdown(content, {
+    filePath: options.path,
+    absoluteFilePath: options.absolutePath
+  });
+  const legacyFindings = [...analysis.errors, ...analysis.warnings]
+    .filter((finding) => !ignoreRules.has(finding.code));
+  const findings = legacyFindings.map((finding) => adaptFinding(finding, options.path));
+
+  return {
+    file: {
+      path: options.path,
+      scanned: true,
+      findings: findings.length,
+      suppressions: findSuppressions(content)
+    },
+    findings
+  };
+}
+
+export { checkWithLegacyEngine };

--- a/src/links.mjs
+++ b/src/links.mjs
@@ -415,6 +415,11 @@ async function checkDeadLinksDetailed(content, {
       if (cache.has(cacheKey)) {
         error = cache.get(cacheKey);
         stats.remoteCacheHits += 1;
+      } else if (timeoutMs == null && cache.has(url)) {
+        // Keep the original URL-only cache contract for callers that use the
+        // default timeout; explicit policies must never share an outcome.
+        error = cache.get(url);
+        stats.remoteCacheHits += 1;
       } else {
         stats.remoteCacheMisses += 1;
         error = await checkRemoteUrl(url, {

--- a/src/links.mjs
+++ b/src/links.mjs
@@ -410,9 +410,10 @@ async function checkDeadLinksDetailed(content, {
     const entries = Array.from(remoteChecks.entries());
     const tasks = entries.map(([url, link]) => async () => {
       let error;
+      const cacheKey = `${timeoutMs || DEFAULT_LINK_TIMEOUT_MS}\0${url}`;
       stats.remoteLinksChecked += 1;
-      if (cache.has(url)) {
-        error = cache.get(url);
+      if (cache.has(cacheKey)) {
+        error = cache.get(cacheKey);
         stats.remoteCacheHits += 1;
       } else {
         stats.remoteCacheMisses += 1;
@@ -423,7 +424,7 @@ async function checkDeadLinksDetailed(content, {
           lookupFn,
           requestFn
         });
-        cache.set(url, error);
+        cache.set(cacheKey, error);
       }
       if (typeof error === 'string' && error.startsWith('Timeout')) {
         stats.remoteTimeouts += 1;

--- a/src/links.mjs
+++ b/src/links.mjs
@@ -324,6 +324,7 @@ async function checkDeadLinksDetailed(content, {
   concurrency,
   remoteCache,
   allowPrivateLinks,
+  checkRemote = true,
   lookupFn,
   requestFn
 } = {}) {
@@ -350,6 +351,7 @@ async function checkDeadLinksDetailed(content, {
     seen.add(dedupeKey);
 
     if (url.startsWith('http://') || url.startsWith('https://')) {
+      if (!checkRemote) continue;
       if (remoteChecks.has(url)) continue;
       if (!allowPrivate) {
         const blocked = await getBlockedRemoteUrlReason(url, { dnsCache, lookupFn });

--- a/src/links.mjs
+++ b/src/links.mjs
@@ -8,6 +8,7 @@ import {
   createPrivateNetworkBlockingLookup,
   getBlockedRemoteUrlReason
 } from './network-guard.mjs';
+import { getReadContainment } from './workspace-path.mjs';
 
 const DEFAULT_LINK_TIMEOUT_MS = 8000;
 const DEFAULT_LINK_CONCURRENCY = 5;
@@ -272,6 +273,21 @@ function checkLocalUrl(url, opts = {}) {
   if (resolved.message) return resolved;
 
   const candidatePaths = resolved.candidatePaths || [resolved.targetPath];
+  if (opts.readBoundary) {
+    for (const candidate of candidatePaths) {
+      const containment = getReadContainment(candidate, opts.readBoundary);
+      if (containment !== 'inside') {
+        return {
+          code: containment === 'outside' ? 'link-outside-workspace' : 'link-unreadable',
+          severity: 'error',
+          operational: true,
+          message: containment === 'outside'
+            ? `Local link is outside the workspace: ${url}`
+            : `Local link cannot be safely resolved: ${url}`
+        };
+      }
+    }
+  }
   if (candidatePaths.some(candidate => fs.existsSync(candidate))) {
     return null;
   }
@@ -287,6 +303,7 @@ function checkLocalUrl(url, opts = {}) {
   return {
     code: 'dead-link',
     severity: 'error',
+    operational: true,
     message: `Dead link: ${url} (Target not found)`
   };
 }
@@ -323,6 +340,7 @@ async function checkDeadLinksDetailed(content, {
   timeoutMs,
   concurrency,
   remoteCache,
+  readBoundary,
   allowPrivateLinks,
   checkRemote = true,
   lookupFn,
@@ -330,6 +348,7 @@ async function checkDeadLinksDetailed(content, {
 } = {}) {
   const links = extractLinks(content);
   const findings = [];
+  const diagnostics = [];
   const seen = new Set();
   const cache = remoteCache instanceof Map ? remoteCache : new Map();
   const dnsCache = new Map();
@@ -371,15 +390,18 @@ async function checkDeadLinksDetailed(content, {
       continue;
     }
 
-    const localFinding = checkLocalUrl(url, { sourceFile, siteRoot });
+    const localFinding = checkLocalUrl(url, { sourceFile, siteRoot, readBoundary });
     if (localFinding) {
-      findings.push({
+      const result = {
         code: localFinding.code,
         severity: localFinding.severity,
+        operational: localFinding.operational === true,
         line: link.line,
         message: localFinding.message,
         source: sourceFile
-      });
+      };
+      findings.push(result);
+      if (localFinding.operational) diagnostics.push(result);
     }
   }
 
@@ -423,7 +445,7 @@ async function checkDeadLinksDetailed(content, {
     }
   }
 
-  return { findings, stats };
+  return { findings, diagnostics, stats };
 }
 
 async function checkDeadLinks(content, opts = {}) {

--- a/src/result-renderers.mjs
+++ b/src/result-renderers.mjs
@@ -61,7 +61,7 @@ function renderText(result, options = {}) {
     for (const diagnostic of fileDiagnostics) representedDiagnostics.add(diagnostic);
     const hasBlocking = findingsForPath(result.findings, file.path)
       .some((finding) => finding.severity === 'blocking');
-    const label = !file.scanned ? 'ERROR' : hasBlocking ? 'FAIL' : 'PASS';
+    const label = !file.scanned || fileDiagnostics.length > 0 ? 'ERROR' : hasBlocking ? 'FAIL' : 'PASS';
     lines.push(`${label} ${terminalText(file.path)}`);
     for (const finding of fileFindings) {
       const location = finding.line == null ? '' : `${finding.line}${finding.column == null ? '' : `:${finding.column}`}: `;
@@ -211,7 +211,7 @@ function renderJunit(result) {
     (diagnostic) => !result.files.some((file) => file.path === diagnostic.path)
   );
   const failures = result.files.filter((file) => findingsForPath(result.findings, file.path).some((finding) => finding.severity === 'blocking')).length;
-  const errors = result.files.filter((file) => !file.scanned).length + orphanDiagnostics.length;
+  const errors = result.files.filter((file) => !file.scanned || diagnosticsForPath(result, file.path).length > 0).length + orphanDiagnostics.length;
   const tests = result.files.length + orphanDiagnostics.length;
   const lines = [
     '<?xml version="1.0" encoding="UTF-8"?>',
@@ -234,7 +234,7 @@ function renderJunit(result) {
     }
 
     lines.push(`  <testcase classname="doclify.guardrail" name="${xmlText(file.path)}">`);
-    if (!file.scanned) {
+    if (!file.scanned || fileDiagnostic) {
       const message = fileDiagnostic?.message || 'File was not scanned.';
       lines.push(`    <error message="${xmlText(message)}">${xmlText(message)}</error>`);
     } else if (blocking.length > 0) {

--- a/src/result-renderers.mjs
+++ b/src/result-renderers.mjs
@@ -1,0 +1,273 @@
+const DEFAULT_HUMAN_FINDING_LIMIT = 50;
+
+function terminalText(value) {
+  return String(value ?? '').replace(/[\u0000-\u001f\u007f-\u009f\u2028\u2029\u202a-\u202e\u2066-\u2069]/g, (character) => {
+    if (character === '\n') return '\\n';
+    if (character === '\r') return '\\r';
+    if (character === '\t') return '\\t';
+    return `\\u${character.charCodeAt(0).toString(16).padStart(4, '0')}`;
+  });
+}
+
+function xmlText(value) {
+  return String(value ?? '')
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g, '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function plural(count, singular, pluralForm = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : pluralForm}`;
+}
+
+function statusLabel(result) {
+  return result.status === 'fail' ? 'FAIL' : result.status === 'incomplete' ? 'INCOMPLETE' : 'PASS';
+}
+
+function findingsForPath(findings, filePath) {
+  return findings.filter((finding) => finding.path === filePath);
+}
+
+function diagnosticsForPath(result, filePath) {
+  return result.diagnostics.filter((diagnostic) => diagnostic.path === filePath);
+}
+
+function suppressionDescription(suppression) {
+  const rules = suppression.rules == null ? 'all rules' : suppression.rules.join(', ');
+  return `${suppression.scope} at line ${suppression.line} (${rules})`;
+}
+
+function limitedHumanFindings(result, options = {}) {
+  if (options.all === true) return { findings: result.findings, omitted: 0 };
+  const requestedLimit = Number(options.limit ?? DEFAULT_HUMAN_FINDING_LIMIT);
+  const limit = Number.isInteger(requestedLimit) && requestedLimit >= 0
+    ? requestedLimit
+    : DEFAULT_HUMAN_FINDING_LIMIT;
+  const findings = result.findings.slice(0, limit);
+  return { findings, omitted: result.findings.length - findings.length };
+}
+
+function renderText(result, options = {}) {
+  const lines = [`Doclify Guardrail ${terminalText(result.tool.version)}`, ''];
+  const representedDiagnostics = new Set();
+  const details = limitedHumanFindings(result, options);
+
+  for (const file of result.files) {
+    const fileFindings = findingsForPath(details.findings, file.path);
+    const fileDiagnostics = diagnosticsForPath(result, file.path);
+    for (const diagnostic of fileDiagnostics) representedDiagnostics.add(diagnostic);
+    const hasBlocking = findingsForPath(result.findings, file.path)
+      .some((finding) => finding.severity === 'blocking');
+    const label = !file.scanned ? 'ERROR' : hasBlocking ? 'FAIL' : 'PASS';
+    lines.push(`${label} ${terminalText(file.path)}`);
+    for (const finding of fileFindings) {
+      const location = finding.line == null ? '' : `${finding.line}${finding.column == null ? '' : `:${finding.column}`}: `;
+      lines.push(`  ${location}${finding.severity} [${terminalText(finding.ruleId)}] ${terminalText(finding.message)}`);
+    }
+    for (const suppression of file.suppressions) {
+      lines.push(`  note [suppression] ${terminalText(suppressionDescription(suppression))}`);
+    }
+    for (const diagnostic of fileDiagnostics) {
+      lines.push(`  error [${terminalText(diagnostic.code)}] ${terminalText(diagnostic.message)}`);
+    }
+  }
+
+  for (const diagnostic of result.diagnostics) {
+    if (representedDiagnostics.has(diagnostic)) continue;
+    lines.push(`ERROR ${terminalText(diagnostic.path)}`);
+    lines.push(`  error [${terminalText(diagnostic.code)}] ${terminalText(diagnostic.message)}`);
+  }
+
+  if (details.omitted > 0) {
+    lines.push('', `${details.omitted} findings omitted; rerun with --all.`);
+  }
+
+  lines.push(
+    '',
+    `Summary: ${statusLabel(result)} | ${result.summary.filesScanned}/${result.summary.filesSelected} files scanned | ${plural(result.summary.blocking, 'blocking finding')} | ${plural(result.summary.advisory, 'advisory finding')} | ${plural(result.summary.diagnostics, 'diagnostic')} | ${result.complete ? 'complete' : 'incomplete'}`,
+    ''
+  );
+  return lines.join('\n');
+}
+
+function renderCompact(result, options = {}) {
+  const lines = [];
+  const details = limitedHumanFindings(result, options);
+  for (const finding of details.findings) {
+    const location = finding.line == null
+      ? finding.path
+      : `${finding.path}:${finding.line}${finding.column == null ? '' : `:${finding.column}`}`;
+    lines.push(`${terminalText(location)}: ${finding.severity} [${terminalText(finding.ruleId)}] ${terminalText(finding.message)}`);
+  }
+  for (const diagnostic of result.diagnostics) {
+    lines.push(`${terminalText(diagnostic.path)}: error [${terminalText(diagnostic.code)}] ${terminalText(diagnostic.message)}`);
+  }
+  for (const file of result.files) {
+    for (const suppression of file.suppressions) {
+      lines.push(`${terminalText(file.path)}:${suppression.line}: note [suppression] ${terminalText(suppressionDescription(suppression))}`);
+    }
+  }
+  if (details.omitted > 0) {
+    lines.push(`${details.omitted} findings omitted; rerun with --all`);
+  }
+  lines.push(`summary: ${result.status}; ${result.summary.filesScanned}/${result.summary.filesSelected} files; ${result.summary.blocking} blocking; ${result.summary.advisory} advisory; ${result.summary.diagnostics} diagnostics; ${result.complete ? 'complete' : 'incomplete'}`);
+  return `${lines.join('\n')}\n`;
+}
+
+function sarifRule(id, message, level) {
+  return {
+    id,
+    name: id,
+    shortDescription: { text: message },
+    defaultConfiguration: { level }
+  };
+}
+
+function renderSarifObject(result) {
+  const rules = new Map();
+  const results = [];
+  for (const finding of result.findings) {
+    const level = finding.severity === 'blocking' ? 'error' : 'warning';
+    if (!rules.has(finding.ruleId)) {
+      rules.set(finding.ruleId, sarifRule(finding.ruleId, finding.message, level));
+    }
+    const physicalLocation = {
+      artifactLocation: { uri: finding.path }
+    };
+    if (finding.line != null) {
+      physicalLocation.region = { startLine: finding.line };
+      if (finding.column != null) physicalLocation.region.startColumn = finding.column;
+    }
+    results.push({
+      ruleId: finding.ruleId,
+      level,
+      message: { text: finding.message },
+      locations: [{ physicalLocation }],
+      properties: {
+        confidence: finding.confidence,
+        evidence: finding.evidence
+      }
+    });
+  }
+  for (const diagnostic of result.diagnostics) {
+    if (!rules.has(diagnostic.code)) {
+      rules.set(diagnostic.code, sarifRule(diagnostic.code, diagnostic.message, 'error'));
+    }
+    results.push({
+      ruleId: diagnostic.code,
+      level: 'error',
+      message: { text: diagnostic.message },
+      locations: [{
+        physicalLocation: {
+          artifactLocation: { uri: diagnostic.path }
+        }
+      }]
+    });
+  }
+  const sortedRules = [...rules.values()].sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+
+  return {
+    $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+    version: '2.1.0',
+    runs: [{
+      tool: {
+        driver: {
+          name: 'Doclify Guardrail',
+          semanticVersion: result.tool.version,
+          informationUri: 'https://github.com/Elgabor/doclify-guardrail',
+          rules: sortedRules
+        }
+      },
+      artifacts: result.files.map((file) => ({
+        location: { uri: file.path },
+        roles: ['analysisTarget'],
+        properties: {
+          scanned: file.scanned,
+          suppressions: file.suppressions
+        }
+      })),
+      results,
+      properties: {
+        schemaVersion: result.schemaVersion,
+        command: result.command,
+        complete: result.complete,
+        status: result.status,
+        summary: result.summary
+      }
+    }]
+  };
+}
+
+function findingLine(finding) {
+  const location = finding.line == null ? '' : `:${finding.line}${finding.column == null ? '' : `:${finding.column}`}`;
+  return `[${finding.severity.toUpperCase()}] ${finding.ruleId}${location} ${finding.message}`;
+}
+
+function renderJunit(result) {
+  const orphanDiagnostics = result.diagnostics.filter(
+    (diagnostic) => !result.files.some((file) => file.path === diagnostic.path)
+  );
+  const failures = result.files.filter((file) => findingsForPath(result.findings, file.path).some((finding) => finding.severity === 'blocking')).length;
+  const errors = result.files.filter((file) => !file.scanned).length + orphanDiagnostics.length;
+  const tests = result.files.length + orphanDiagnostics.length;
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<testsuite name="doclify-guardrail" tests="${tests}" failures="${failures}" errors="${errors}">`
+  ];
+
+  for (const file of result.files) {
+    const fileFindings = findingsForPath(result.findings, file.path);
+    const blocking = fileFindings.filter((finding) => finding.severity === 'blocking');
+    const advisory = fileFindings.filter((finding) => finding.severity === 'advisory');
+    const fileDiagnostic = diagnosticsForPath(result, file.path)[0];
+    const notes = [
+      ...advisory.map(findingLine),
+      ...file.suppressions.map((suppression) => `[SUPPRESSION] ${suppressionDescription(suppression)}`)
+    ];
+
+    if (file.scanned && blocking.length === 0 && notes.length === 0) {
+      lines.push(`  <testcase classname="doclify.guardrail" name="${xmlText(file.path)}"/>`);
+      continue;
+    }
+
+    lines.push(`  <testcase classname="doclify.guardrail" name="${xmlText(file.path)}">`);
+    if (!file.scanned) {
+      const message = fileDiagnostic?.message || 'File was not scanned.';
+      lines.push(`    <error message="${xmlText(message)}">${xmlText(message)}</error>`);
+    } else if (blocking.length > 0) {
+      const message = plural(blocking.length, 'blocking finding');
+      lines.push(`    <failure message="${xmlText(message)}">${xmlText(blocking.map(findingLine).join('\n'))}</failure>`);
+    }
+    if (notes.length > 0) {
+      lines.push(`    <system-out>${xmlText(notes.join('\n'))}</system-out>`);
+    }
+    lines.push('  </testcase>');
+  }
+
+  for (const diagnostic of orphanDiagnostics) {
+    lines.push(`  <testcase classname="doclify.guardrail.operational" name="${xmlText(diagnostic.path)}">`);
+    lines.push(`    <error message="${xmlText(diagnostic.message)}">${xmlText(diagnostic.message)}</error>`);
+    lines.push('  </testcase>');
+  }
+
+  lines.push('</testsuite>', '');
+  return lines.join('\n');
+}
+
+function renderResult(result, options = {}) {
+  const format = options.format || 'text';
+  if (format === 'text') return renderText(result, options);
+  if (format === 'compact') return renderCompact(result, options);
+  if (format === 'json') return `${JSON.stringify(result, null, 2)}\n`;
+  if (format === 'sarif') return `${JSON.stringify(renderSarifObject(result), null, 2)}\n`;
+  if (format === 'junit') return renderJunit(result);
+  throw new Error(`Unsupported result format: ${format}`);
+}
+
+export {
+  renderResult,
+  terminalText
+};

--- a/src/result-renderers.mjs
+++ b/src/result-renderers.mjs
@@ -228,7 +228,7 @@ function renderJunit(result) {
       ...file.suppressions.map((suppression) => `[SUPPRESSION] ${suppressionDescription(suppression)}`)
     ];
 
-    if (file.scanned && blocking.length === 0 && notes.length === 0) {
+    if (file.scanned && !fileDiagnostic && blocking.length === 0 && notes.length === 0) {
       lines.push(`  <testcase classname="doclify.guardrail" name="${xmlText(file.path)}"/>`);
       continue;
     }

--- a/src/result.mjs
+++ b/src/result.mjs
@@ -1,0 +1,81 @@
+import { compareText } from './text-order.mjs';
+
+function compareOptionalNumber(left, right) {
+  const a = Number.isInteger(left) ? left : Number.MAX_SAFE_INTEGER;
+  const b = Number.isInteger(right) ? right : Number.MAX_SAFE_INTEGER;
+  return a - b;
+}
+
+function compareFindings(left, right) {
+  return compareText(left.path, right.path)
+    || compareOptionalNumber(left.line, right.line)
+    || compareOptionalNumber(left.column, right.column)
+    || compareText(left.ruleId, right.ruleId)
+    || compareText(left.message, right.message);
+}
+
+function compareDiagnostics(left, right) {
+  return compareText(left.path, right.path)
+    || compareText(left.code, right.code)
+    || compareText(left.message, right.message);
+}
+
+function compareSuppressions(left, right) {
+  return compareOptionalNumber(left.line, right.line)
+    || compareText(left.scope, right.scope)
+    || compareText((left.rules || []).join(','), (right.rules || []).join(','));
+}
+
+function normalizeFile(file) {
+  return {
+    path: String(file.path),
+    scanned: Boolean(file.scanned),
+    findings: file.scanned ? Number(file.findings || 0) : null,
+    suppressions: [...(file.suppressions || [])]
+      .map((suppression) => ({
+        scope: String(suppression.scope),
+        rules: suppression.rules == null ? null : [...suppression.rules].map(String).sort(compareText),
+        line: Number(suppression.line)
+      }))
+      .sort(compareSuppressions)
+  };
+}
+
+function createResult(options = {}) {
+  const fullFiles = [...(options.files || [])]
+    .map(normalizeFile)
+    .sort((left, right) => compareText(left.path, right.path));
+  const fullFindings = [...(options.findings || [])].sort(compareFindings);
+  const fullDiagnostics = [...(options.diagnostics || [])].sort(compareDiagnostics);
+  const blocking = fullFindings.filter((finding) => finding.severity === 'blocking').length;
+  const advisory = fullFindings.length - blocking;
+  const complete = fullDiagnostics.length === 0;
+  const status = blocking > 0 ? 'fail' : complete ? 'pass' : 'incomplete';
+
+  return {
+    schemaVersion: 3,
+    tool: {
+      name: 'doclify-guardrail',
+      version: String(options.toolVersion)
+    },
+    command: options.command === 'changed' ? 'changed' : 'check',
+    complete,
+    status,
+    summary: {
+      filesSelected: fullFiles.length,
+      filesScanned: fullFiles.filter((file) => file.scanned).length,
+      filesSkipped: fullFiles.filter((file) => !file.scanned).length,
+      blocking,
+      advisory,
+      diagnostics: fullDiagnostics.length,
+      filesWithSuppressions: fullFiles.filter((file) => file.suppressions.length > 0).length
+    },
+    files: fullFiles,
+    findings: fullFindings,
+    diagnostics: fullDiagnostics
+  };
+}
+
+export {
+  createResult
+};

--- a/src/suppressions.mjs
+++ b/src/suppressions.mjs
@@ -1,0 +1,39 @@
+import { analyzeFences } from './fences.mjs';
+import { normalizeLineEndings } from './text-normalize.mjs';
+
+const DIRECTIVES = [
+  { scope: 'file', pattern: /<!--\s*doclify-disable-file\s*(.*?)\s*-->/ },
+  { scope: 'next-line', pattern: /<!--\s*doclify-disable-next-line\s*(.*?)\s*-->/ },
+  { scope: 'block-end', pattern: /<!--\s*doclify-enable\s*(.*?)\s*-->/ },
+  { scope: 'block-start', pattern: /<!--\s*doclify-disable\s*(.*?)\s*-->/ }
+];
+
+function parseRuleIds(raw) {
+  const trimmed = String(raw || '').trim();
+  if (!trimmed) return null;
+  return trimmed.split(/[,\s]+/).map((value) => value.trim()).filter(Boolean);
+}
+
+function findSuppressions(content) {
+  const lines = normalizeLineEndings(content).split('\n');
+  const fences = analyzeFences(lines);
+  const suppressions = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (fences.inFence[index]) continue;
+    for (const directive of DIRECTIVES) {
+      const match = lines[index].match(directive.pattern);
+      if (!match) continue;
+      suppressions.push({
+        scope: directive.scope,
+        rules: parseRuleIds(match[1]),
+        line: index + 1
+      });
+      break;
+    }
+  }
+
+  return suppressions;
+}
+
+export { findSuppressions };

--- a/src/target-selector.mjs
+++ b/src/target-selector.mjs
@@ -1,0 +1,227 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { miniGlob } from './glob.mjs';
+import { isMarkdownPath } from './markdown-files.mjs';
+import { compareText } from './text-order.mjs';
+import { isDescendantOrSame } from './workspace-path.mjs';
+
+const IGNORED_DIRECTORIES = new Set([
+  'node_modules',
+  '.git',
+  'Pods',
+  '.symlinks',
+  '.plugin_symlinks',
+  '.dart_tool',
+  'vendor',
+  'build',
+  'dist',
+  '.next',
+  '.nuxt',
+  'coverage',
+  '.cache',
+  '__pycache__',
+  '.venv',
+  'venv',
+  'ephemeral'
+]);
+
+class TargetSelectionError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'TargetSelectionError';
+    this.code = code;
+  }
+}
+
+function toPortablePath(value) {
+  return String(value).split(path.sep).join('/');
+}
+
+function relativePath(filePath, workspace) {
+  const relative = path.relative(workspace, filePath);
+  return toPortablePath(relative || '.');
+}
+
+function wildcardPattern(pattern) {
+  const escaped = toPortablePath(pattern)
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '\u0000')
+    .replace(/\*/g, '[^/]*')
+    .replace(/\u0000/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+function isExcluded(relative, patterns) {
+  const portable = toPortablePath(relative);
+  const segments = portable.split('/');
+  return patterns.some((rawPattern) => {
+    const pattern = toPortablePath(rawPattern).replace(/^\.\//, '').replace(/\/$/, '');
+    if (!pattern) return false;
+    if (pattern.includes('*')) return wildcardPattern(pattern).test(portable);
+    return portable === pattern || portable.startsWith(`${pattern}/`) || segments.includes(pattern);
+  });
+}
+
+function selectionDiagnostic(code, target, message) {
+  return {
+    code,
+    severity: 'error',
+    path: toPortablePath(target),
+    message
+  };
+}
+
+function walkDirectory(dirPath, workspace, exclude, paths, diagnostics) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  } catch (error) {
+    diagnostics.push(selectionDiagnostic(
+      'directory-unreadable',
+      relativePath(dirPath, workspace),
+      `Unable to read directory (${error?.code || 'UNKNOWN'}).`
+    ));
+    return;
+  }
+
+  entries.sort((left, right) => compareText(left.name, right.name));
+  for (const entry of entries) {
+    const absolute = path.join(dirPath, entry.name);
+    const relative = relativePath(absolute, workspace);
+    if (isExcluded(relative, exclude)) continue;
+    if (IGNORED_DIRECTORIES.has(entry.name)) continue;
+    if (entry.isDirectory()) {
+      walkDirectory(absolute, workspace, exclude, paths, diagnostics);
+      continue;
+    }
+    if (entry.isFile() && isMarkdownPath(entry.name)) {
+      paths.push(absolute);
+      continue;
+    }
+    if (!entry.isSymbolicLink() || !isMarkdownPath(entry.name)) continue;
+
+    let targetStat;
+    try {
+      targetStat = fs.statSync(absolute);
+    } catch (error) {
+      diagnostics.push(selectionDiagnostic(
+        'target-unreadable',
+        relative,
+        `Unable to inspect symbolic link target (${error?.code || 'UNKNOWN'}).`
+      ));
+      continue;
+    }
+    if (!isDescendantOrSame(absolute, workspace)) {
+      diagnostics.push(selectionDiagnostic(
+        'target-outside-workspace',
+        relative,
+        'Symbolic link target is outside the workspace.'
+      ));
+      continue;
+    }
+    if (targetStat.isFile()) {
+      paths.push(absolute);
+    } else {
+      diagnostics.push(selectionDiagnostic(
+        'target-unsupported',
+        relative,
+        'Markdown symbolic link target must be a file.'
+      ));
+    }
+  }
+}
+
+function assertContained(candidate, workspace) {
+  if (!isDescendantOrSame(candidate, workspace)) {
+    throw new TargetSelectionError(
+      'target-outside-workspace',
+      'Selected paths must stay inside the workspace.'
+    );
+  }
+}
+
+function selectTargets(options = {}) {
+  const workspace = path.resolve(options.cwd || process.cwd());
+  const targets = Array.isArray(options.paths) ? options.paths : ['.'];
+  const exclude = [...(options.exclude || [])];
+  const selected = [];
+  const diagnostics = [];
+
+  for (const rawTarget of targets) {
+    const target = String(rawTarget);
+    if (target.includes('*')) {
+      const wildcardIndex = target.indexOf('*');
+      const prefix = target.slice(0, wildcardIndex);
+      const prefixPath = path.resolve(workspace, prefix || '.');
+      assertContained(prefixPath, workspace);
+      let matches;
+      try {
+        matches = miniGlob(target, workspace);
+      } catch (error) {
+        diagnostics.push(selectionDiagnostic(
+          'target-unreadable',
+          target,
+          `Unable to inspect target (${error?.code || 'UNKNOWN'}).`
+        ));
+        continue;
+      }
+      const contained = matches.filter((candidate) => isDescendantOrSame(candidate, workspace));
+      const usable = contained.filter((candidate) => {
+        const relative = relativePath(candidate, workspace);
+        return isMarkdownPath(candidate) && !isExcluded(relative, exclude);
+      });
+      if (usable.length === 0) {
+        diagnostics.push(selectionDiagnostic(
+          'target-unmatched',
+          target,
+          'No Markdown files matched target.'
+        ));
+      } else {
+        selected.push(...usable);
+      }
+      continue;
+    }
+
+    const absolute = path.resolve(workspace, target);
+    assertContained(absolute, workspace);
+    let stat;
+    try {
+      stat = fs.statSync(absolute);
+    } catch {
+      if (isMarkdownPath(absolute)) {
+        selected.push(absolute);
+      } else {
+        diagnostics.push(selectionDiagnostic(
+          'target-unreadable',
+          target,
+          'Target does not exist or cannot be inspected.'
+        ));
+      }
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      walkDirectory(absolute, workspace, exclude, selected, diagnostics);
+    } else if (stat.isFile() && isMarkdownPath(absolute)) {
+      const relative = relativePath(absolute, workspace);
+      if (!isExcluded(relative, exclude)) selected.push(absolute);
+    } else {
+      diagnostics.push(selectionDiagnostic(
+        'target-unsupported',
+        target,
+        'Target must be a Markdown or MDX file or a directory.'
+      ));
+    }
+  }
+
+  const paths = [...new Set(selected.map((candidate) => path.resolve(candidate)))]
+    .sort((left, right) => compareText(relativePath(left, workspace), relativePath(right, workspace)));
+  return { workspace, paths, diagnostics };
+}
+
+export {
+  TargetSelectionError,
+  relativePath,
+  selectTargets
+};

--- a/src/target-selector.mjs
+++ b/src/target-selector.mjs
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { miniGlob } from './glob.mjs';
 import { isMarkdownPath } from './markdown-files.mjs';
 import { compareText } from './text-order.mjs';
-import { isDescendantOrSame } from './workspace-path.mjs';
+import { getReadContainment, isDescendantOrSame } from './workspace-path.mjs';
 
 const IGNORED_DIRECTORIES = new Set([
   'node_modules',
@@ -43,26 +43,6 @@ function relativePath(filePath, workspace) {
   return toPortablePath(relative || '.');
 }
 
-function wildcardPattern(pattern) {
-  const escaped = toPortablePath(pattern)
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\*\*/g, '\u0000')
-    .replace(/\*/g, '[^/]*')
-    .replace(/\u0000/g, '.*');
-  return new RegExp(`^${escaped}$`);
-}
-
-function isExcluded(relative, patterns) {
-  const portable = toPortablePath(relative);
-  const segments = portable.split('/');
-  return patterns.some((rawPattern) => {
-    const pattern = toPortablePath(rawPattern).replace(/^\.\//, '').replace(/\/$/, '');
-    if (!pattern) return false;
-    if (pattern.includes('*')) return wildcardPattern(pattern).test(portable);
-    return portable === pattern || portable.startsWith(`${pattern}/`) || segments.includes(pattern);
-  });
-}
-
 function selectionDiagnostic(code, target, message) {
   return {
     code,
@@ -72,7 +52,7 @@ function selectionDiagnostic(code, target, message) {
   };
 }
 
-function walkDirectory(dirPath, workspace, exclude, paths, diagnostics) {
+function walkDirectory(dirPath, workspace, shouldExclude, paths, diagnostics) {
   let entries;
   try {
     entries = fs.readdirSync(dirPath, { withFileTypes: true });
@@ -89,12 +69,13 @@ function walkDirectory(dirPath, workspace, exclude, paths, diagnostics) {
   for (const entry of entries) {
     const absolute = path.join(dirPath, entry.name);
     const relative = relativePath(absolute, workspace);
-    if (isExcluded(relative, exclude)) continue;
     if (IGNORED_DIRECTORIES.has(entry.name)) continue;
     if (entry.isDirectory()) {
-      walkDirectory(absolute, workspace, exclude, paths, diagnostics);
+      if (shouldExclude(absolute, { directory: true })) continue;
+      walkDirectory(absolute, workspace, shouldExclude, paths, diagnostics);
       continue;
     }
+    if (shouldExclude(absolute)) continue;
     if (entry.isFile() && isMarkdownPath(entry.name)) {
       paths.push(absolute);
       continue;
@@ -133,7 +114,7 @@ function walkDirectory(dirPath, workspace, exclude, paths, diagnostics) {
 }
 
 function assertContained(candidate, workspace) {
-  if (!isDescendantOrSame(candidate, workspace)) {
+  if (getReadContainment(candidate, workspace) === 'outside') {
     throw new TargetSelectionError(
       'target-outside-workspace',
       'Selected paths must stay inside the workspace.'
@@ -144,7 +125,9 @@ function assertContained(candidate, workspace) {
 function selectTargets(options = {}) {
   const workspace = path.resolve(options.cwd || process.cwd());
   const targets = Array.isArray(options.paths) ? options.paths : ['.'];
-  const exclude = [...(options.exclude || [])];
+  const shouldExclude = typeof options.isExcluded === 'function'
+    ? options.isExcluded
+    : () => false;
   const selected = [];
   const diagnostics = [];
 
@@ -166,10 +149,9 @@ function selectTargets(options = {}) {
         ));
         continue;
       }
-      const contained = matches.filter((candidate) => isDescendantOrSame(candidate, workspace));
+      const contained = matches.filter((candidate) => getReadContainment(candidate, workspace) !== 'outside');
       const usable = contained.filter((candidate) => {
-        const relative = relativePath(candidate, workspace);
-        return isMarkdownPath(candidate) && !isExcluded(relative, exclude);
+        return isMarkdownPath(candidate) && !shouldExclude(candidate);
       });
       if (usable.length === 0) {
         diagnostics.push(selectionDiagnostic(
@@ -190,7 +172,7 @@ function selectTargets(options = {}) {
       stat = fs.statSync(absolute);
     } catch {
       if (isMarkdownPath(absolute)) {
-        selected.push(absolute);
+        if (!shouldExclude(absolute)) selected.push(absolute);
       } else {
         diagnostics.push(selectionDiagnostic(
           'target-unreadable',
@@ -202,10 +184,11 @@ function selectTargets(options = {}) {
     }
 
     if (stat.isDirectory()) {
-      walkDirectory(absolute, workspace, exclude, selected, diagnostics);
+      if (!shouldExclude(absolute, { directory: true })) {
+        walkDirectory(absolute, workspace, shouldExclude, selected, diagnostics);
+      }
     } else if (stat.isFile() && isMarkdownPath(absolute)) {
-      const relative = relativePath(absolute, workspace);
-      if (!isExcluded(relative, exclude)) selected.push(absolute);
+      if (!shouldExclude(absolute)) selected.push(absolute);
     } else {
       diagnostics.push(selectionDiagnostic(
         'target-unsupported',

--- a/src/text-order.mjs
+++ b/src/text-order.mjs
@@ -1,0 +1,7 @@
+function compareText(left, right) {
+  const a = String(left ?? '');
+  const b = String(right ?? '');
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export { compareText };

--- a/src/v2-cli.mjs
+++ b/src/v2-cli.mjs
@@ -182,6 +182,12 @@ function safeDiagnostic(error) {
   return `${terminalText(code)}: ${terminalText(message)}\n`;
 }
 
+function writeOperationalDiagnostics(result) {
+  for (const diagnostic of result.diagnostics) {
+    process.stderr.write(`${terminalText(diagnostic.path)}: error [${terminalText(diagnostic.code)}] ${terminalText(diagnostic.message)}\n`);
+  }
+}
+
 function assertOutputDoesNotOverwriteInput(outputPath, result, workspace) {
   const canonical = (candidate) => {
     try {
@@ -191,9 +197,24 @@ function assertOutputDoesNotOverwriteInput(outputPath, result, workspace) {
     }
   };
   const canonicalOutput = canonical(outputPath);
+  let outputIdentity = null;
+  try {
+    const outputStat = fs.statSync(outputPath, { bigint: true });
+    outputIdentity = `${outputStat.dev}:${outputStat.ino}`;
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
   for (const file of result.files) {
-    const inputPath = canonical(path.resolve(workspace, file.path));
-    if (canonicalOutput === inputPath) {
+    const inputPath = path.resolve(workspace, file.path);
+    const canonicalInput = canonical(inputPath);
+    let inputIdentity = null;
+    try {
+      const inputStat = fs.statSync(inputPath, { bigint: true });
+      inputIdentity = `${inputStat.dev}:${inputStat.ino}`;
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+    if (canonicalOutput === canonicalInput || (outputIdentity != null && outputIdentity === inputIdentity)) {
       throw new DoclifyUsageError('output-overwrites-input', 'Output path must not overwrite a scanned document.');
     }
   }
@@ -243,6 +264,7 @@ async function runV2Cli(argv) {
     } else {
       process.stdout.write(rendered);
     }
+    writeOperationalDiagnostics(result);
     return result.status === 'pass' ? 0 : 1;
   } catch (error) {
     process.stderr.write(safeDiagnostic(error));

--- a/src/v2-cli.mjs
+++ b/src/v2-cli.mjs
@@ -1,8 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { check, DoclifyUsageError } from './core.mjs';
-import { getChangedMarkdownFiles } from './diff.mjs';
+import { DoclifyUsageError, runCheck } from './core.mjs';
 import { renderResult, terminalText } from './result-renderers.mjs';
 import { resolveWorkspacePath } from './workspace-path.mjs';
 
@@ -43,8 +42,9 @@ function parseV2Args(argv) {
     help: false,
     ignoreRules: [],
     exclude: [],
+    config: null,
     siteRoot: null,
-    externalLinks: false,
+    externalLinks: undefined,
     links: { allowList: [] },
     base: null,
     staged: false
@@ -89,6 +89,11 @@ function parseV2Args(argv) {
     }
     if (token === '--site-root') {
       parsed.siteRoot = takeValue(argv, index, token);
+      index += 1;
+      continue;
+    }
+    if (token === '--config') {
+      parsed.config = takeValue(argv, index, token);
       index += 1;
       continue;
     }
@@ -144,9 +149,6 @@ function parseV2Args(argv) {
       throw new DoclifyUsageError('invalid-changed-selector', 'changed requires exactly one of --base or --staged.');
     }
   }
-  if (!parsed.externalLinks && (parsed.links.allowList.length > 0 || parsed.links.timeoutMs != null || parsed.links.concurrency != null)) {
-    throw new DoclifyUsageError('invalid-link-options', 'Remote link options require --external-links.');
-  }
   if (command === 'check' && parsed.paths.length === 0) parsed.paths.push('.');
   return parsed;
 }
@@ -158,6 +160,7 @@ function renderV2Help(command) {
     '  --all                              Show every finding in text/compact output',
     '  --ignore-rules <id,...>',
     '  --exclude <path,...>',
+    '  --config <path>',
     '  --site-root <path>',
     '  --external-links',
     '  --link-allow-list <url,...>',
@@ -205,41 +208,36 @@ async function runV2Cli(argv) {
       return 0;
     }
 
-    let paths = parsed.paths;
-    if (parsed.command === 'changed') {
-      try {
-        paths = getChangedMarkdownFiles({
-          base: parsed.base || 'HEAD',
-          staged: parsed.staged
-        });
-      } catch {
-        throw new DoclifyUsageError('git-failed', 'Changed-file discovery failed.');
-      }
-    }
-
-    const result = await check({
+    const checkOptions = {
       command: parsed.command,
       cwd: process.cwd(),
-      paths,
       ignoreRules: parsed.ignoreRules,
       exclude: parsed.exclude,
-      siteRoot: parsed.siteRoot,
-      externalLinks: parsed.externalLinks,
       links: parsed.links
-    });
+    };
+    if (parsed.command === 'changed') {
+      checkOptions.changed = parsed.staged ? { staged: true } : { base: parsed.base };
+    } else {
+      checkOptions.paths = parsed.paths;
+    }
+    if (parsed.config != null) checkOptions.config = parsed.config;
+    if (parsed.siteRoot != null) checkOptions.siteRoot = parsed.siteRoot;
+    if (parsed.externalLinks === true) checkOptions.externalLinks = true;
+
+    const { result, workspace } = await runCheck(checkOptions);
     const rendered = renderResult(result, { format: parsed.format, all: parsed.all });
 
     if (parsed.output) {
       let outputPath;
       try {
-        outputPath = resolveWorkspacePath(parsed.output, {
-          workspace: process.cwd(),
+        outputPath = resolveWorkspacePath(path.resolve(process.cwd(), parsed.output), {
+          workspace,
           label: 'Output path'
         });
       } catch {
         throw new DoclifyUsageError('output-outside-workspace', 'Output path must stay inside the workspace.');
       }
-      assertOutputDoesNotOverwriteInput(outputPath, result, process.cwd());
+      assertOutputDoesNotOverwriteInput(outputPath, result, workspace);
       fs.mkdirSync(path.dirname(outputPath), { recursive: true });
       fs.writeFileSync(outputPath, rendered, 'utf8');
     } else {

--- a/src/v2-cli.mjs
+++ b/src/v2-cli.mjs
@@ -1,0 +1,262 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { check, DoclifyUsageError } from './core.mjs';
+import { getChangedMarkdownFiles } from './diff.mjs';
+import { renderResult, terminalText } from './result-renderers.mjs';
+import { resolveWorkspacePath } from './workspace-path.mjs';
+
+const COMMANDS = new Set(['check', 'changed']);
+const FORMATS = new Set(['text', 'compact', 'json', 'sarif', 'junit']);
+
+function takeValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('-')) {
+    throw new DoclifyUsageError('invalid-option', `Missing value for ${flag}.`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(raw, flag) {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new DoclifyUsageError('invalid-option', `${flag} must be a positive integer.`);
+  }
+  return value;
+}
+
+function appendList(target, raw) {
+  target.push(...raw.split(',').map((value) => value.trim()).filter(Boolean));
+}
+
+function parseV2Args(argv) {
+  const command = argv[0];
+  if (!COMMANDS.has(command)) {
+    throw new DoclifyUsageError('invalid-command', 'Expected check or changed.');
+  }
+  const parsed = {
+    command,
+    paths: [],
+    format: 'text',
+    output: null,
+    all: false,
+    help: false,
+    ignoreRules: [],
+    exclude: [],
+    siteRoot: null,
+    externalLinks: false,
+    links: { allowList: [] },
+    base: null,
+    staged: false
+  };
+
+  for (let index = 1; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '-h' || token === '--help') {
+      parsed.help = true;
+      continue;
+    }
+    if (token === '--format') {
+      const value = takeValue(argv, index, token);
+      if (!FORMATS.has(value)) {
+        throw new DoclifyUsageError('invalid-format', `Invalid format: ${value}.`);
+      }
+      parsed.format = value;
+      index += 1;
+      continue;
+    }
+    if (token === '--output') {
+      parsed.output = takeValue(argv, index, token);
+      index += 1;
+      continue;
+    }
+    if (token === '--all') {
+      parsed.all = true;
+      continue;
+    }
+    if (token === '--no-color') {
+      continue;
+    }
+    if (token === '--ignore-rules') {
+      appendList(parsed.ignoreRules, takeValue(argv, index, token));
+      index += 1;
+      continue;
+    }
+    if (token === '--exclude') {
+      appendList(parsed.exclude, takeValue(argv, index, token));
+      index += 1;
+      continue;
+    }
+    if (token === '--site-root') {
+      parsed.siteRoot = takeValue(argv, index, token);
+      index += 1;
+      continue;
+    }
+    if (token === '--external-links') {
+      parsed.externalLinks = true;
+      continue;
+    }
+    if (token === '--link-allow-list') {
+      appendList(parsed.links.allowList, takeValue(argv, index, token));
+      index += 1;
+      continue;
+    }
+    if (token === '--link-timeout-ms') {
+      parsed.links.timeoutMs = parsePositiveInteger(takeValue(argv, index, token), token);
+      index += 1;
+      continue;
+    }
+    if (token === '--link-concurrency') {
+      parsed.links.concurrency = parsePositiveInteger(takeValue(argv, index, token), token);
+      index += 1;
+      continue;
+    }
+    if (token === '--base') {
+      if (command !== 'changed') {
+        throw new DoclifyUsageError('invalid-option', '--base is only valid with changed.');
+      }
+      parsed.base = takeValue(argv, index, token);
+      index += 1;
+      continue;
+    }
+    if (token === '--staged') {
+      if (command !== 'changed') {
+        throw new DoclifyUsageError('invalid-option', '--staged is only valid with changed.');
+      }
+      parsed.staged = true;
+      continue;
+    }
+    if (token === '--json') {
+      throw new DoclifyUsageError('legacy-option', 'Use --format json with the v2 command grammar.');
+    }
+    if (token.startsWith('-')) {
+      throw new DoclifyUsageError('unknown-option', `Unknown option: ${token}.`);
+    }
+    if (command === 'changed') {
+      throw new DoclifyUsageError('unexpected-target', 'changed does not accept positional paths.');
+    }
+    parsed.paths.push(token);
+  }
+
+  if (command === 'changed' && !parsed.help) {
+    const selectors = Number(parsed.base != null) + Number(parsed.staged);
+    if (selectors !== 1) {
+      throw new DoclifyUsageError('invalid-changed-selector', 'changed requires exactly one of --base or --staged.');
+    }
+  }
+  if (!parsed.externalLinks && (parsed.links.allowList.length > 0 || parsed.links.timeoutMs != null || parsed.links.concurrency != null)) {
+    throw new DoclifyUsageError('invalid-link-options', 'Remote link options require --external-links.');
+  }
+  if (command === 'check' && parsed.paths.length === 0) parsed.paths.push('.');
+  return parsed;
+}
+
+function renderV2Help(command) {
+  const common = [
+    '  --format <text|compact|json|sarif|junit>',
+    '  --output <path>',
+    '  --all                              Show every finding in text/compact output',
+    '  --ignore-rules <id,...>',
+    '  --exclude <path,...>',
+    '  --site-root <path>',
+    '  --external-links',
+    '  --link-allow-list <url,...>',
+    '  --link-timeout-ms <n>',
+    '  --link-concurrency <n>',
+    '  --no-color                         Accepted; human output is always color-free'
+  ];
+  const usage = command === 'changed'
+    ? 'doclify-guardrail changed (--base <ref> | --staged) [options]'
+    : 'doclify-guardrail check [paths...] [options]';
+  return `${usage}\n\nOptions:\n${common.join('\n')}\n`;
+}
+
+function safeDiagnostic(error) {
+  const code = error?.code || 'internal-error';
+  const message = error instanceof DoclifyUsageError
+    ? error.message
+    : 'The command could not complete.';
+  return `${terminalText(code)}: ${terminalText(message)}\n`;
+}
+
+function assertOutputDoesNotOverwriteInput(outputPath, result, workspace) {
+  const canonical = (candidate) => {
+    try {
+      return fs.realpathSync(candidate);
+    } catch {
+      return path.resolve(candidate);
+    }
+  };
+  const canonicalOutput = canonical(outputPath);
+  for (const file of result.files) {
+    const inputPath = canonical(path.resolve(workspace, file.path));
+    if (canonicalOutput === inputPath) {
+      throw new DoclifyUsageError('output-overwrites-input', 'Output path must not overwrite a scanned document.');
+    }
+  }
+}
+
+async function runV2Cli(argv) {
+  let parsed;
+  try {
+    parsed = parseV2Args(argv);
+    if (parsed.help) {
+      process.stdout.write(renderV2Help(parsed.command));
+      return 0;
+    }
+
+    let paths = parsed.paths;
+    if (parsed.command === 'changed') {
+      try {
+        paths = getChangedMarkdownFiles({
+          base: parsed.base || 'HEAD',
+          staged: parsed.staged
+        });
+      } catch {
+        throw new DoclifyUsageError('git-failed', 'Changed-file discovery failed.');
+      }
+    }
+
+    const result = await check({
+      command: parsed.command,
+      cwd: process.cwd(),
+      paths,
+      ignoreRules: parsed.ignoreRules,
+      exclude: parsed.exclude,
+      siteRoot: parsed.siteRoot,
+      externalLinks: parsed.externalLinks,
+      links: parsed.links
+    });
+    const rendered = renderResult(result, { format: parsed.format, all: parsed.all });
+
+    if (parsed.output) {
+      let outputPath;
+      try {
+        outputPath = resolveWorkspacePath(parsed.output, {
+          workspace: process.cwd(),
+          label: 'Output path'
+        });
+      } catch {
+        throw new DoclifyUsageError('output-outside-workspace', 'Output path must stay inside the workspace.');
+      }
+      assertOutputDoesNotOverwriteInput(outputPath, result, process.cwd());
+      fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+      fs.writeFileSync(outputPath, rendered, 'utf8');
+    } else {
+      process.stdout.write(rendered);
+    }
+    return result.status === 'pass' ? 0 : 1;
+  } catch (error) {
+    process.stderr.write(safeDiagnostic(error));
+    return 2;
+  }
+}
+
+function isV2Command(argv) {
+  return COMMANDS.has(argv[0]);
+}
+
+export {
+  isV2Command,
+  runV2Cli
+};

--- a/src/workspace-path.mjs
+++ b/src/workspace-path.mjs
@@ -50,9 +50,6 @@ function isDescendantOrSame(candidatePath, basePath) {
 }
 
 function getReadContainment(candidatePath, basePath) {
-  const lexicalRelative = path.relative(path.resolve(basePath), path.resolve(candidatePath));
-  if (lexicalRelative.startsWith('..') || path.isAbsolute(lexicalRelative)) return 'outside';
-
   const resolvedCandidate = canonicalizeForBoundaryCheck(candidatePath);
   const resolvedBase = canonicalizeForBoundaryCheck(basePath);
   if (resolvedCandidate == null || resolvedBase == null) return 'indeterminate';

--- a/src/workspace-path.mjs
+++ b/src/workspace-path.mjs
@@ -49,6 +49,19 @@ function isDescendantOrSame(candidatePath, basePath) {
   return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
 }
 
+function getReadContainment(candidatePath, basePath) {
+  const lexicalRelative = path.relative(path.resolve(basePath), path.resolve(candidatePath));
+  if (lexicalRelative.startsWith('..') || path.isAbsolute(lexicalRelative)) return 'outside';
+
+  const resolvedCandidate = canonicalizeForBoundaryCheck(candidatePath);
+  const resolvedBase = canonicalizeForBoundaryCheck(basePath);
+  if (resolvedCandidate == null || resolvedBase == null) return 'indeterminate';
+  const canonicalRelative = path.relative(resolvedBase, resolvedCandidate);
+  return canonicalRelative === '' || (!canonicalRelative.startsWith('..') && !path.isAbsolute(canonicalRelative))
+    ? 'inside'
+    : 'outside';
+}
+
 function resolveWorkspacePath(targetPath, options = {}) {
   const workspace = path.resolve(options.workspace || process.cwd());
   const label = options.label || 'Output path';
@@ -60,6 +73,7 @@ function resolveWorkspacePath(targetPath, options = {}) {
 }
 
 export {
+  getReadContainment,
   isDescendantOrSame,
   resolveWorkspacePath
 };

--- a/src/workspace-path.mjs
+++ b/src/workspace-path.mjs
@@ -1,28 +1,50 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-function canonicalizeForBoundaryCheck(targetPath) {
+function canonicalizeForBoundaryCheck(targetPath, seenLinks = new Set()) {
   const resolved = path.resolve(targetPath);
-  if (fs.existsSync(resolved)) {
-    try {
-      return fs.realpathSync(resolved);
-    } catch {
-      return resolved;
-    }
-  }
 
-  const parentDir = path.dirname(resolved);
-  try {
-    const canonicalParent = fs.realpathSync(parentDir);
-    return path.join(canonicalParent, path.basename(resolved));
-  } catch {
-    return resolved;
+  let current = resolved;
+  const remainder = [];
+  while (true) {
+    let stat;
+    try {
+      stat = fs.lstatSync(current);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') return null;
+      const parent = path.dirname(current);
+      if (parent === current) return null;
+      remainder.unshift(path.basename(current));
+      current = parent;
+      continue;
+    }
+
+    if (stat.isSymbolicLink()) {
+      if (seenLinks.has(current)) return null;
+      const nextSeenLinks = new Set(seenLinks);
+      nextSeenLinks.add(current);
+      let linkTarget;
+      try {
+        linkTarget = fs.readlinkSync(current);
+      } catch {
+        return null;
+      }
+      const resolvedTarget = path.resolve(path.dirname(current), linkTarget);
+      return canonicalizeForBoundaryCheck(path.join(resolvedTarget, ...remainder), nextSeenLinks);
+    }
+
+    try {
+      return path.join(fs.realpathSync(current), ...remainder);
+    } catch {
+      return null;
+    }
   }
 }
 
 function isDescendantOrSame(candidatePath, basePath) {
   const resolvedCandidate = canonicalizeForBoundaryCheck(candidatePath);
   const resolvedBase = canonicalizeForBoundaryCheck(basePath);
+  if (resolvedCandidate == null || resolvedBase == null) return false;
   const rel = path.relative(resolvedBase, resolvedCandidate);
   return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
 }

--- a/test/golden/v2-result.json
+++ b/test/golden/v2-result.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": 3,
+  "tool": {
+    "name": "doclify-guardrail",
+    "version": "2.0.0-test"
+  },
+  "command": "check",
+  "complete": false,
+  "status": "fail",
+  "summary": {
+    "filesSelected": 4,
+    "filesScanned": 3,
+    "filesSkipped": 1,
+    "blocking": 1,
+    "advisory": 1,
+    "diagnostics": 1,
+    "filesWithSuppressions": 1
+  },
+  "files": [
+    {
+      "path": "a-broken.md",
+      "scanned": true,
+      "findings": 1,
+      "suppressions": []
+    },
+    {
+      "path": "b-suppressed.md",
+      "scanned": true,
+      "findings": 1,
+      "suppressions": [
+        {
+          "scope": "file",
+          "rules": null,
+          "line": 1
+        }
+      ]
+    },
+    {
+      "path": "locked.md",
+      "scanned": false,
+      "findings": null,
+      "suppressions": []
+    },
+    {
+      "path": "z-clean.md",
+      "scanned": true,
+      "findings": 0,
+      "suppressions": []
+    }
+  ],
+  "findings": [
+    {
+      "ruleId": "single-h1",
+      "severity": "blocking",
+      "confidence": "high",
+      "path": "a-broken.md",
+      "line": 1,
+      "column": null,
+      "message": "Missing H1 heading.",
+      "evidence": {
+        "fact": "No H1 heading was found.",
+        "source": "a-broken.md:1"
+      }
+    },
+    {
+      "ruleId": "placeholder",
+      "severity": "advisory",
+      "confidence": "unverified",
+      "path": "b-suppressed.md",
+      "line": 4,
+      "column": null,
+      "message": "Placeholder found.",
+      "evidence": null
+    }
+  ],
+  "diagnostics": [
+    {
+      "code": "file-unreadable",
+      "severity": "error",
+      "path": "locked.md",
+      "message": "Unable to read file (EACCES)."
+    }
+  ]
+}

--- a/test/golden/v2-result.junit
+++ b/test/golden/v2-result.junit
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="doclify-guardrail" tests="4" failures="1" errors="1">
+  <testcase classname="doclify.guardrail" name="a-broken.md">
+    <failure message="1 blocking finding">[BLOCKING] single-h1:1 Missing H1 heading.</failure>
+  </testcase>
+  <testcase classname="doclify.guardrail" name="b-suppressed.md">
+    <system-out>[ADVISORY] placeholder:4 Placeholder found.
+[SUPPRESSION] file at line 1 (all rules)</system-out>
+  </testcase>
+  <testcase classname="doclify.guardrail" name="locked.md">
+    <error message="Unable to read file (EACCES).">Unable to read file (EACCES).</error>
+  </testcase>
+  <testcase classname="doclify.guardrail" name="z-clean.md"/>
+</testsuite>

--- a/test/golden/v2-result.sarif
+++ b/test/golden/v2-result.sarif
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Doclify Guardrail",
+          "semanticVersion": "2.0.0-test",
+          "informationUri": "https://github.com/Elgabor/doclify-guardrail",
+          "rules": [
+            {
+              "id": "file-unreadable",
+              "name": "file-unreadable",
+              "shortDescription": {
+                "text": "Unable to read file (EACCES)."
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              }
+            },
+            {
+              "id": "placeholder",
+              "name": "placeholder",
+              "shortDescription": {
+                "text": "Placeholder found."
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "single-h1",
+              "name": "single-h1",
+              "shortDescription": {
+                "text": "Missing H1 heading."
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              }
+            }
+          ]
+        }
+      },
+      "artifacts": [
+        {
+          "location": {
+            "uri": "a-broken.md"
+          },
+          "roles": [
+            "analysisTarget"
+          ],
+          "properties": {
+            "scanned": true,
+            "suppressions": []
+          }
+        },
+        {
+          "location": {
+            "uri": "b-suppressed.md"
+          },
+          "roles": [
+            "analysisTarget"
+          ],
+          "properties": {
+            "scanned": true,
+            "suppressions": [
+              {
+                "scope": "file",
+                "rules": null,
+                "line": 1
+              }
+            ]
+          }
+        },
+        {
+          "location": {
+            "uri": "locked.md"
+          },
+          "roles": [
+            "analysisTarget"
+          ],
+          "properties": {
+            "scanned": false,
+            "suppressions": []
+          }
+        },
+        {
+          "location": {
+            "uri": "z-clean.md"
+          },
+          "roles": [
+            "analysisTarget"
+          ],
+          "properties": {
+            "scanned": true,
+            "suppressions": []
+          }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "single-h1",
+          "level": "error",
+          "message": {
+            "text": "Missing H1 heading."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "a-broken.md"
+                },
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "properties": {
+            "confidence": "high",
+            "evidence": {
+              "fact": "No H1 heading was found.",
+              "source": "a-broken.md:1"
+            }
+          }
+        },
+        {
+          "ruleId": "placeholder",
+          "level": "warning",
+          "message": {
+            "text": "Placeholder found."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "b-suppressed.md"
+                },
+                "region": {
+                  "startLine": 4
+                }
+              }
+            }
+          ],
+          "properties": {
+            "confidence": "unverified",
+            "evidence": null
+          }
+        },
+        {
+          "ruleId": "file-unreadable",
+          "level": "error",
+          "message": {
+            "text": "Unable to read file (EACCES)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "locked.md"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "properties": {
+        "schemaVersion": 3,
+        "command": "check",
+        "complete": false,
+        "status": "fail",
+        "summary": {
+          "filesSelected": 4,
+          "filesScanned": 3,
+          "filesSkipped": 1,
+          "blocking": 1,
+          "advisory": 1,
+          "diagnostics": 1,
+          "filesWithSuppressions": 1
+        }
+      }
+    }
+  ]
+}

--- a/test/golden/v2-result.text
+++ b/test/golden/v2-result.text
@@ -1,0 +1,12 @@
+Doclify Guardrail 2.0.0-test
+
+FAIL a-broken.md
+  1: blocking [single-h1] Missing H1 heading.
+PASS b-suppressed.md
+  4: advisory [placeholder] Placeholder found.
+  note [suppression] file at line 1 (all rules)
+ERROR locked.md
+  error [file-unreadable] Unable to read file (EACCES).
+PASS z-clean.md
+
+Summary: FAIL | 3/4 files scanned | 1 blocking finding | 1 advisory finding | 1 diagnostic | incomplete

--- a/test/guardrail.test.mjs
+++ b/test/guardrail.test.mjs
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
 import http from 'node:http';
+import { fileURLToPath } from 'node:url';
 import { checkMarkdown, parseArgs, resolveOptions, resolveFileOptions, findParentConfigs } from '../src/index.mjs';
 import { stripCodeBlocks } from '../src/checker.mjs';
 import { resolveFileList, findMarkdownFiles } from '../src/glob.mjs';
@@ -50,9 +51,10 @@ import {
   generateBadge
 } from '../src/ci-output.mjs';
 
-const CLI_PATH = path.resolve('src/index.mjs');
-const ACTION_DIST_PATH = path.resolve('action/dist/index.mjs');
-const PKG_VERSION = JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf8')).version;
+const REPOSITORY_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI_PATH = path.join(REPOSITORY_ROOT, 'src', 'index.mjs');
+const ACTION_DIST_PATH = path.join(REPOSITORY_ROOT, 'action', 'dist', 'index.mjs');
+const PKG_VERSION = JSON.parse(fs.readFileSync(path.join(REPOSITORY_ROOT, 'package.json'), 'utf8')).version;
 
 function makeTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'doclify-guardrail-'));
@@ -2548,7 +2550,10 @@ test('CLI: --format compact produces single-line output', () => {
 
 // --diff (tests in a git repo context)
 test('CLI: --diff flag is accepted without error', () => {
-  const r = spawnSync('node', [CLI_PATH, '--diff', '--ascii'], { encoding: 'utf8' });
+  const r = spawnSync('node', [CLI_PATH, '--diff', '--ascii'], {
+    cwd: REPOSITORY_ROOT,
+    encoding: 'utf8'
+  });
   // Should not return exit code 2 (usage error)
   assert.notEqual(r.status, 2);
 });
@@ -2622,7 +2627,7 @@ test('API: score() computes health score', () => {
 // getChangedMarkdownFiles
 test('diff: getChangedMarkdownFiles returns array', () => {
   // This test runs in a git repo, so it should work
-  const files = getChangedMarkdownFiles({ base: 'HEAD' });
+  const files = getChangedMarkdownFiles({ base: 'HEAD', cwd: REPOSITORY_ROOT });
   assert.ok(Array.isArray(files));
 });
 

--- a/test/test-isolation.test.mjs
+++ b/test/test-isolation.test.mjs
@@ -1,0 +1,280 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { runTestProfile } from '../scripts/check-test-isolation.mjs';
+import { comparePerformance, generateCorpus, ruleSetMetadata } from '../scripts/perf-corpus.mjs';
+import {
+  captureRepositoryState,
+  cleanupStaleSandboxes,
+  compareRepositoryStates,
+  createIsolatedEnvironment,
+  snapshotTree
+} from '../scripts/test-isolation.mjs';
+
+const TEST_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
+const ISOLATION_MODULE = path.resolve(TEST_DIRECTORY, '..', 'scripts', 'test-isolation.mjs');
+const PERFORMANCE_SCRIPT = path.resolve(TEST_DIRECTORY, '..', 'scripts', 'perf-corpus.mjs');
+
+function makeTempDir(t) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'doclify-isolation-test-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+function initRepository(t) {
+  const root = makeTempDir(t);
+  assert.equal(spawnSync('git', ['init', '-q'], { cwd: root }).status, 0);
+  return root;
+}
+
+test('correctness profile runs inside one isolated temp and Doclify home', () => {
+  const sandbox = process.env.DOCLIFY_TEST_SANDBOX;
+  assert.ok(sandbox, 'tests must run through the isolation profile');
+  assert.equal(path.resolve(os.tmpdir()), path.resolve(sandbox));
+  assert.equal(path.relative(sandbox, process.env.DOCLIFY_HOME).startsWith('..'), false);
+  assert.equal(Object.hasOwn(process.env, 'DOCLIFY_TOKEN'), false);
+  assert.equal(Object.hasOwn(process.env, 'DOCLIFY_API_KEY'), false);
+});
+
+test('repository guard detects writes inside ignored nested Git directories', (t) => {
+  const root = initRepository(t);
+  fs.writeFileSync(path.join(root, '.gitignore'), '.cache/\n', 'utf8');
+  fs.mkdirSync(path.join(root, '.cache'), { recursive: true });
+  fs.writeFileSync(path.join(root, '.cache', 'keep'), 'stable\n', 'utf8');
+  const before = captureRepositoryState(root);
+
+  const objectDirectory = path.join(root, '.cache', 'corpus', 'fixture', '.git', 'objects');
+  fs.mkdirSync(objectDirectory, { recursive: true });
+  fs.writeFileSync(path.join(objectDirectory, 'object'), 'new\n', 'utf8');
+  const after = captureRepositoryState(root);
+  const comparison = compareRepositoryStates(before, after);
+
+  assert.equal(before.gitStatus, after.gitStatus);
+  assert.equal(comparison.unchanged, false);
+  assert.equal(comparison.treeChanged, true);
+  assert.equal(comparison.changes.some((change) => change.includes('.git/objects')), true);
+});
+
+test('correctness runner fails when a test writes into its repository', async (t) => {
+  const root = initRepository(t);
+  const leakedFile = path.join(root, 'leaked.txt');
+  const leakingTest = path.join(root, 'leaking.test.mjs');
+  fs.writeFileSync(leakingTest, [
+    "import fs from 'node:fs';",
+    "import test from 'node:test';",
+    `test('leak', () => fs.writeFileSync(${JSON.stringify(leakedFile)}, 'leak\\n'));`
+  ].join('\n'), 'utf8');
+  const messages = [];
+  const output = {
+    stdout: { write: (message) => messages.push(message) },
+    stderr: { write: (message) => messages.push(message) }
+  };
+
+  const code = await runTestProfile({
+    repositoryRoot: root,
+    files: [leakingTest],
+    output,
+    stdio: 'ignore'
+  });
+
+  assert.equal(code, 1);
+  assert.equal(fs.existsSync(leakedFile), true);
+  assert.match(messages.join(''), /repository state changed/);
+});
+
+test('correctness runner reports a repository made uninspectable by a test', async (t) => {
+  if (typeof process.getuid !== 'function' || process.getuid() === 0 || process.platform === 'win32') {
+    t.skip('requires Unix ownership permissions');
+    return;
+  }
+  const root = initRepository(t);
+  const lockedDirectory = path.join(root, 'locked');
+  const leakingTest = path.join(root, 'locking.test.mjs');
+  fs.writeFileSync(leakingTest, [
+    "import fs from 'node:fs';",
+    "import test from 'node:test';",
+    `test('lock', () => { fs.mkdirSync(${JSON.stringify(lockedDirectory)}); fs.chmodSync(${JSON.stringify(lockedDirectory)}, 0); });`
+  ].join('\n'), 'utf8');
+
+  try {
+    await assert.rejects(
+      runTestProfile({
+        repositoryRoot: root,
+        files: [leakingTest],
+        stdio: 'ignore'
+      }),
+      /Repository became uninspectable during the test run: Cannot inspect repository path "locked" \(EACCES\)/
+    );
+  } finally {
+    if (fs.existsSync(lockedDirectory)) fs.chmodSync(lockedDirectory, 0o700);
+  }
+});
+
+test('repository guard distinguishes metadata-only changes', (t) => {
+  const root = makeTempDir(t);
+  const file = path.join(root, 'ignored.log');
+  fs.writeFileSync(file, 'stable\n', 'utf8');
+  const before = snapshotTree(root);
+  const future = new Date(Date.now() + 60_000);
+  fs.utimesSync(file, future, future);
+  const after = snapshotTree(root);
+  const comparison = compareRepositoryStates(
+    { gitStatus: '', tree: before },
+    { gitStatus: '', tree: after }
+  );
+  assert.equal(comparison.unchanged, false);
+  assert.match(comparison.changes[0], /^timestamps changed/);
+});
+
+test('isolated environment replaces personal Doclify and temp configuration', (t) => {
+  const sandbox = makeTempDir(t);
+  const environment = createIsolatedEnvironment(sandbox);
+  assert.equal(environment.TMPDIR, sandbox);
+  assert.equal(path.relative(sandbox, environment.DOCLIFY_HOME).startsWith('..'), false);
+  for (const name of [
+    'HOME',
+    'DOCLIFY_TOKEN',
+    'DOCLIFY_API_KEY',
+    'DOCLIFY_API_URL',
+    'DOCLIFY_PROJECT_ID',
+    'DOCLIFY_REPO_ID',
+    'NODE_AUTH_TOKEN',
+    'NPM_TOKEN'
+  ]) {
+    assert.equal(Object.hasOwn(environment, name), false, `${name} must not be inherited`);
+  }
+});
+
+test('stale sandbox cleanup removes only old matching directories', (t) => {
+  const root = makeTempDir(t);
+  const oldDirectory = path.join(root, 'case-old');
+  const recentDirectory = path.join(root, 'case-recent');
+  const unrelated = path.join(root, 'other-old');
+  fs.mkdirSync(oldDirectory);
+  fs.mkdirSync(recentDirectory);
+  fs.mkdirSync(unrelated);
+  const now = Date.now();
+  fs.utimesSync(oldDirectory, new Date(now - 20_000), new Date(now - 20_000));
+  fs.utimesSync(unrelated, new Date(now - 20_000), new Date(now - 20_000));
+
+  const removed = cleanupStaleSandboxes(root, { prefix: 'case-', olderThanMs: 10_000, now });
+  assert.deepEqual(removed, [oldDirectory]);
+  assert.equal(fs.existsSync(oldDirectory), false);
+  assert.equal(fs.existsSync(recentDirectory), true);
+  assert.equal(fs.existsSync(unrelated), true);
+});
+
+for (const [signal, expectedCode] of [['SIGINT', 130], ['SIGTERM', 143]]) {
+  test(`cleanup handler removes its sandbox on ${signal}`, async (t) => {
+    const root = makeTempDir(t);
+    const sandbox = path.join(root, 'signal-sandbox');
+    fs.mkdirSync(sandbox);
+    const moduleUrl = pathToFileURL(ISOLATION_MODULE).href;
+    const source = [
+      `import { installCleanupHandlers, removeSandbox } from ${JSON.stringify(moduleUrl)};`,
+      'const sandbox = process.env.DOCLIFY_SIGNAL_SANDBOX;',
+      'installCleanupHandlers(() => removeSandbox(sandbox));',
+      "process.stdout.write('ready\\n');",
+      'setInterval(() => {}, 1000);'
+    ].join('\n');
+    const child = spawn(process.execPath, ['--input-type=module', '-e', source], {
+      env: {
+        PATH: process.env.PATH || '',
+        DOCLIFY_SIGNAL_SANDBOX: sandbox
+      },
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    t.after(() => {
+      if (child.exitCode == null && child.signalCode == null) child.kill('SIGKILL');
+    });
+
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('cleanup child did not become ready')), 3000);
+      child.stdout.once('data', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+      child.once('error', reject);
+    });
+    child.kill(signal);
+    const exit = await new Promise((resolve) => child.once('exit', (code, exitSignal) => resolve({ code, signal: exitSignal })));
+    assert.deepEqual(exit, { code: expectedCode, signal: null });
+    assert.equal(fs.existsSync(sandbox), false);
+  });
+}
+
+test('performance corpus is deterministic and comparison enforces rule hash and tolerance', (t) => {
+  const firstRoot = makeTempDir(t);
+  const secondRoot = makeTempDir(t);
+  const first = generateCorpus(firstRoot, { documents: 20 });
+  const second = generateCorpus(secondRoot, { documents: 20 });
+  assert.deepEqual(first, second);
+  assert.throws(
+    () => generateCorpus(firstRoot, { documents: 11 }),
+    /positive multiple of 10/
+  );
+
+  const ruleSet = ruleSetMetadata();
+  const observation = {
+    corpus: first,
+    ruleSet,
+    environment: { class: 'fixture', ci: false },
+    cold: { p95Ms: 120 },
+    warm: { p95Ms: 80 }
+  };
+  const baseline = {
+    schemaVersion: 1,
+    corpus: first,
+    ruleSet,
+    environments: {
+      fixture: {
+        cold: { p95Ms: 100 },
+        warm: { p95Ms: 70 }
+      }
+    },
+    tolerance: { localPct: 10, ciPct: 100, absoluteFloorMs: 25 }
+  };
+  assert.equal(comparePerformance(observation, baseline).pass, true);
+
+  const ciObservation = structuredClone(observation);
+  ciObservation.environment.ci = true;
+  ciObservation.cold.p95Ms = 180;
+  ciObservation.warm.p95Ms = 120;
+  assert.equal(comparePerformance(ciObservation, baseline).pass, true);
+  ciObservation.environment.ci = false;
+  assert.equal(comparePerformance(ciObservation, baseline).pass, false);
+
+  const unrecorded = structuredClone(observation);
+  unrecorded.environment.class = 'unrecorded-environment';
+  assert.deepEqual(comparePerformance(unrecorded, baseline), {
+    pass: true,
+    status: 'unrecorded',
+    failures: [],
+    limits: null
+  });
+
+  const slow = structuredClone(observation);
+  slow.warm.p95Ms = 200;
+  assert.equal(comparePerformance(slow, baseline).pass, false);
+
+  const changedRules = structuredClone(observation);
+  changedRules.ruleSet.hash = 'sha256:different';
+  assert.equal(comparePerformance(changedRules, baseline).pass, false);
+});
+
+test('performance profile rejects unknown options before creating a corpus', (t) => {
+  const root = makeTempDir(t);
+  const result = spawnSync(process.execPath, [PERFORMANCE_SCRIPT, '--bogus'], {
+    cwd: root,
+    env: process.env,
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unknown option: --bogus/);
+  assert.equal(fs.existsSync(path.join(root, 'corpus')), false);
+});

--- a/test/test-isolation.test.mjs
+++ b/test/test-isolation.test.mjs
@@ -265,6 +265,21 @@ test('performance corpus is deterministic and comparison enforces rule hash and 
   const changedRules = structuredClone(observation);
   changedRules.ruleSet.hash = 'sha256:different';
   assert.equal(comparePerformance(changedRules, baseline).pass, false);
+
+  for (const mutate of [
+    (candidate) => { candidate.tolerance.absoluteFloorMs = 'not-a-number'; },
+    (candidate) => { candidate.environments.fixture.cold.p95Ms = Number.NaN; },
+    (candidate) => { candidate.environments.fixture.warm.p95Ms = -1; }
+  ]) {
+    const malformed = structuredClone(baseline);
+    mutate(malformed);
+    assert.deepEqual(comparePerformance(observation, malformed), {
+      pass: false,
+      status: 'fail',
+      failures: ['Performance baseline tolerance is invalid.'],
+      limits: null
+    });
+  }
 });
 
 test('performance profile rejects unknown options before creating a corpus', (t) => {

--- a/test/v2-contract.test.mjs
+++ b/test/v2-contract.test.mjs
@@ -172,6 +172,26 @@ test('v2 human output is bounded while machine formats stay complete', () => {
   assert.match(renderResult(result, { format: 'junit' }), /Placeholder 55\./);
 });
 
+test('v2 text and JUnit render diagnostics for a scanned file as errors', () => {
+  const result = createResult({
+    toolVersion: '2.0.0-test',
+    command: 'check',
+    files: [{ path: 'doc.md', scanned: true, findings: 0, suppressions: [] }],
+    findings: [],
+    diagnostics: [{
+      code: 'dead-link',
+      severity: 'error',
+      path: 'doc.md',
+      message: 'Dead link: missing.md (Target not found)'
+    }]
+  });
+
+  assert.match(renderResult(result, { format: 'text' }), /^ERROR doc\.md/m);
+  const junit = renderResult(result, { format: 'junit' });
+  assert.match(junit, /tests="1" failures="0" errors="1"/);
+  assert.match(junit, /<error message="Dead link: missing\.md \(Target not found\)">/);
+});
+
 test('v2 CLI and API return the same schemaVersion 3 result', async (t) => {
   const cwd = makeTempDir(t);
   fs.writeFileSync(path.join(cwd, 'doc.md'), 'Body without a heading.\n', 'utf8');
@@ -302,6 +322,26 @@ test('v2 local link checks remain offline unless external links are explicit', a
   assert.equal(findings.some((finding) => finding.code === 'dead-link'), true);
   assert.equal(findings.some((finding) => finding.message.includes('example.com')), false);
   assert.equal(stats.remoteLinksChecked, 0);
+});
+
+test('v2 remote cache keeps results separate for different timeout policies', async () => {
+  const cache = new Map();
+  const timeouts = [];
+  const requestFn = (_url, _options, timeoutMs) => {
+    timeouts.push(timeoutMs);
+    return { status: 200, headers: { get: () => null } };
+  };
+  const options = {
+    sourceFile: '/workspace/doc.md',
+    checkRemote: true,
+    remoteCache: cache,
+    lookupFn: async () => [{ address: '93.184.216.34', family: 4 }],
+    requestFn
+  };
+
+  await checkDeadLinksDetailed('[example](https://example.com)', { ...options, timeoutMs: 25 });
+  await checkDeadLinksDetailed('[example](https://example.com)', { ...options, timeoutMs: 50 });
+  assert.deepEqual(timeouts, [25, 50]);
 });
 
 test('v2 local links never inspect outside the selected workspace', async (t) => {

--- a/test/v2-contract.test.mjs
+++ b/test/v2-contract.test.mjs
@@ -224,12 +224,12 @@ test('v2 unreadable targets stay structured while empty scans and invalid usage 
 
   await assert.rejects(
     check({ cwd, paths: ['.'], config: '.doclify-guardrail.json' }),
-    (error) => error?.name === 'DoclifyUsageError' && error?.code === 'unknown-option'
+    (error) => error?.name === 'DoclifyUsageError' && error?.code === 'config-not-found'
   );
   const config = runCli(['check', '.', '--config', '.doclify-guardrail.json'], cwd);
   assert.equal(config.status, 2);
   assert.equal(config.stdout, '');
-  assert.match(config.stderr, /^unknown-option:/);
+  assert.match(config.stderr, /^config-not-found:/);
 });
 
 test('v2 unmatched targets cannot be hidden by a clean target', async (t) => {

--- a/test/v2-contract.test.mjs
+++ b/test/v2-contract.test.mjs
@@ -1,0 +1,477 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { check } from '../src/api.mjs';
+import { checkDeadLinksDetailed } from '../src/links.mjs';
+import { createResult } from '../src/result.mjs';
+import { renderResult, terminalText } from '../src/result-renderers.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(ROOT, 'src', 'index.mjs');
+const GOLDEN_DIR = path.join(ROOT, 'test', 'golden');
+
+function makeTempDir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doclify-v2-contract-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function runCli(args, cwd) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      LANG: 'C',
+      NO_COLOR: '1',
+      PATH: process.env.PATH || ''
+    }
+  });
+}
+
+function readGolden(name) {
+  return fs.readFileSync(path.join(GOLDEN_DIR, name), 'utf8');
+}
+
+function contractResult() {
+  return createResult({
+    toolVersion: '2.0.0-test',
+    command: 'check',
+    files: [
+      { path: 'z-clean.md', scanned: true, findings: 0, suppressions: [] },
+      {
+        path: 'b-suppressed.md',
+        scanned: true,
+        findings: 1,
+        suppressions: [{ scope: 'file', rules: null, line: 1 }]
+      },
+      { path: 'a-broken.md', scanned: true, findings: 1, suppressions: [] },
+      { path: 'locked.md', scanned: false, findings: null, suppressions: [] }
+    ],
+    findings: [
+      {
+        ruleId: 'placeholder',
+        severity: 'advisory',
+        confidence: 'unverified',
+        path: 'b-suppressed.md',
+        line: 4,
+        column: null,
+        message: 'Placeholder found.',
+        evidence: null
+      },
+      {
+        ruleId: 'single-h1',
+        severity: 'blocking',
+        confidence: 'high',
+        path: 'a-broken.md',
+        line: 1,
+        column: null,
+        message: 'Missing H1 heading.',
+        evidence: {
+          fact: 'No H1 heading was found.',
+          source: 'a-broken.md:1'
+        }
+      }
+    ],
+    diagnostics: [
+      {
+        code: 'file-unreadable',
+        severity: 'error',
+        path: 'locked.md',
+        message: 'Unable to read file (EACCES).'
+      }
+    ]
+  });
+}
+
+test('v2 result is deterministic, flat, and distinguishes incomplete scans', () => {
+  const result = contractResult();
+
+  assert.equal(result.schemaVersion, 3);
+  assert.equal(result.complete, false);
+  assert.equal(result.status, 'fail');
+  assert.deepEqual(result.files.map((file) => file.path), [
+    'a-broken.md',
+    'b-suppressed.md',
+    'locked.md',
+    'z-clean.md'
+  ]);
+  assert.deepEqual(result.findings.map((finding) => `${finding.path}:${finding.line}:${finding.ruleId}`), [
+    'a-broken.md:1:single-h1',
+    'b-suppressed.md:4:placeholder'
+  ]);
+  assert.deepEqual(result.summary, {
+    filesSelected: 4,
+    filesScanned: 3,
+    filesSkipped: 1,
+    blocking: 1,
+    advisory: 1,
+    diagnostics: 1,
+    filesWithSuppressions: 1
+  });
+});
+
+test('v2 terminal output escapes control and bidirectional formatting characters', () => {
+  assert.equal(terminalText('safe\u001b[31m\u202etext'), 'safe\\u001b[31m\\u202etext');
+});
+
+test('v2 --no-color remains a color-free compatibility option', (t) => {
+  const cwd = makeTempDir(t);
+  fs.writeFileSync(path.join(cwd, 'doc.md'), '# Clean\n', 'utf8');
+
+  const regular = runCli(['check', 'doc.md'], cwd);
+  const noColor = runCli(['check', 'doc.md', '--no-color'], cwd);
+  assert.equal(noColor.status, 0, noColor.stderr);
+  assert.equal(noColor.stderr, '');
+  assert.equal(noColor.stdout, regular.stdout);
+  assert.doesNotMatch(noColor.stdout, /\u001b\[/);
+});
+
+for (const format of ['text', 'json', 'sarif', 'junit']) {
+  test(`v2 ${format} renderer matches its golden contract`, () => {
+    assert.equal(renderResult(contractResult(), { format }), readGolden(`v2-result.${format}`));
+  });
+}
+
+test('v2 human output is bounded while machine formats stay complete', () => {
+  const findings = Array.from({ length: 55 }, (_, index) => ({
+    ruleId: 'placeholder',
+    severity: 'advisory',
+    confidence: 'unverified',
+    path: 'many.md',
+    line: index + 1,
+    column: null,
+    message: `Placeholder ${index + 1}.`,
+    evidence: null
+  }));
+  const files = [{ path: 'many.md', scanned: true, findings: 55, suppressions: [] }];
+  findings[54].severity = 'blocking';
+  const result = createResult({ toolVersion: '2.0.0-test', command: 'check', files, findings, diagnostics: [] });
+  const compact = renderResult(result, { format: 'compact' });
+  const completeCompact = renderResult(result, { format: 'compact', all: true });
+
+  assert.equal(result.findings.length, 55);
+  assert.equal(result.summary.advisory, 54);
+  assert.equal(result.summary.blocking, 1);
+  assert.equal(result.files[0].findings, 55);
+  assert.equal((compact.match(/\[placeholder\]/g) || []).length, 50);
+  assert.match(compact, /5 findings omitted; rerun with --all/);
+  assert.equal((completeCompact.match(/\[placeholder\]/g) || []).length, 55);
+  assert.doesNotMatch(completeCompact, /findings omitted/);
+  assert.equal(JSON.parse(renderResult(result, { format: 'json' })).findings.length, 55);
+  assert.equal(JSON.parse(renderResult(result, { format: 'sarif' })).runs[0].results.length, 55);
+  assert.match(renderResult(result, { format: 'junit' }), /tests="1" failures="1" errors="0"/);
+  assert.match(renderResult(result, { format: 'junit' }), /Placeholder 55\./);
+});
+
+test('v2 CLI and API return the same schemaVersion 3 result', async (t) => {
+  const cwd = makeTempDir(t);
+  fs.writeFileSync(path.join(cwd, 'doc.md'), 'Body without a heading.\n', 'utf8');
+
+  const apiResult = await check({ cwd, paths: ['doc.md'] });
+  const cli = runCli(['check', 'doc.md', '--format', 'json'], cwd);
+
+  assert.equal(cli.status, 0, cli.stderr);
+  assert.equal(cli.stderr, '');
+  assert.deepEqual(JSON.parse(cli.stdout), apiResult);
+  assert.equal(apiResult.schemaVersion, 3);
+  assert.equal(apiResult.findings[0].severity, 'advisory');
+  assert.equal(apiResult.findings[0].confidence, 'unverified');
+  assert.equal(apiResult.findings[0].evidence, null);
+});
+
+test('v2 partial scan returns a structured incomplete result and exit 1', async (t) => {
+  const cwd = makeTempDir(t);
+  fs.writeFileSync(path.join(cwd, 'clean.md'), '# Clean\n', 'utf8');
+
+  const apiResult = await check({ cwd, paths: ['clean.md', 'missing.md'] });
+  const cli = runCli(['check', 'clean.md', 'missing.md', '--format', 'json', '--all'], cwd);
+
+  assert.equal(apiResult.complete, false);
+  assert.equal(apiResult.status, 'incomplete');
+  assert.equal(apiResult.summary.blocking, 0);
+  assert.equal(apiResult.diagnostics[0].code, 'file-unreadable');
+  assert.equal(apiResult.files.find((file) => file.path === 'missing.md').findings, null);
+  assert.equal(cli.status, 1, cli.stderr);
+  assert.equal(cli.stderr, '');
+  assert.deepEqual(JSON.parse(cli.stdout), apiResult);
+});
+
+test('v2 unreadable targets stay structured while empty scans and invalid usage exit 2', async (t) => {
+  const cwd = makeTempDir(t);
+
+  const missing = runCli(['check', 'missing.md', '--format', 'json'], cwd);
+  assert.equal(missing.status, 1, missing.stderr);
+  assert.equal(missing.stderr, '');
+  const missingResult = JSON.parse(missing.stdout);
+  assert.equal(missingResult.status, 'incomplete');
+  assert.equal(missingResult.files[0].scanned, false);
+  assert.equal(missingResult.diagnostics[0].code, 'file-unreadable');
+
+  const empty = runCli(['check', '.', '--format', 'json'], cwd);
+  assert.equal(empty.status, 2);
+  assert.equal(empty.stdout, '');
+  assert.match(empty.stderr, /^scan-failed:/);
+
+  const legacyFlag = runCli(['check', '--json'], cwd);
+  assert.equal(legacyFlag.status, 2);
+  assert.equal(legacyFlag.stdout, '');
+  assert.match(legacyFlag.stderr, /Use --format json/);
+
+  await assert.rejects(
+    check({ cwd, paths: ['.'], config: '.doclify-guardrail.json' }),
+    (error) => error?.name === 'DoclifyUsageError' && error?.code === 'unknown-option'
+  );
+  const config = runCli(['check', '.', '--config', '.doclify-guardrail.json'], cwd);
+  assert.equal(config.status, 2);
+  assert.equal(config.stdout, '');
+  assert.match(config.stderr, /^unknown-option:/);
+});
+
+test('v2 unmatched targets cannot be hidden by a clean target', async (t) => {
+  const cwd = makeTempDir(t);
+  fs.writeFileSync(path.join(cwd, 'clean.md'), '# Clean\n', 'utf8');
+
+  const result = await check({ cwd, paths: ['clean.md', 'missing/**/*.md'] });
+  assert.equal(result.status, 'incomplete');
+  assert.equal(result.complete, false);
+  assert.equal(result.diagnostics[0].code, 'target-unmatched');
+});
+
+test('v2 suppression metadata distinguishes a fully suppressed file from a clean file', async (t) => {
+  const cwd = makeTempDir(t);
+  fs.writeFileSync(path.join(cwd, 'clean.md'), '# Clean\n', 'utf8');
+  fs.writeFileSync(path.join(cwd, 'suppressed.md'), '<!-- doclify-disable-file -->\nNo heading.\n', 'utf8');
+  fs.writeFileSync(
+    path.join(cwd, 'fenced.md'),
+    '# Fenced\r\n\r\n```md\r\n<!-- doclify-disable-file -->\r\n```\r\n',
+    'utf8'
+  );
+
+  const result = await check({ cwd, paths: ['suppressed.md', 'clean.md', 'fenced.md'] });
+  const clean = result.files.find((file) => file.path === 'clean.md');
+  const suppressed = result.files.find((file) => file.path === 'suppressed.md');
+  const fenced = result.files.find((file) => file.path === 'fenced.md');
+
+  assert.deepEqual(clean.suppressions, []);
+  assert.deepEqual(suppressed.suppressions, [{ scope: 'file', rules: null, line: 1 }]);
+  assert.deepEqual(fenced.suppressions, []);
+  assert.equal(result.summary.filesWithSuppressions, 1);
+});
+
+test('v2 suppression metadata follows checker fence and rule-list semantics', async (t) => {
+  const cwd = makeTempDir(t);
+  fs.writeFileSync(
+    path.join(cwd, 'directives.md'),
+    '# Directives\r\n\r\n<!-- doclify-disable-next-line placeholder -->\r\nTODO later.\r\n<!-- doclify-disable single-h1, placeholder -->\r\nText.\r\n<!-- doclify-enable single-h1 placeholder -->\r\n',
+    'utf8'
+  );
+
+  const result = await check({ cwd, paths: ['directives.md'] });
+  assert.deepEqual(result.files[0].suppressions, [
+    { scope: 'next-line', rules: ['placeholder'], line: 3 },
+    { scope: 'block-start', rules: ['placeholder', 'single-h1'], line: 5 },
+    { scope: 'block-end', rules: ['placeholder', 'single-h1'], line: 7 }
+  ]);
+  assert.equal(result.findings.some((finding) => finding.ruleId === 'placeholder' && finding.line === 4), false);
+});
+
+test('v2 local link checks remain offline unless external links are explicit', async (t) => {
+  const cwd = makeTempDir(t);
+  const sourceFile = path.join(cwd, 'doc.md');
+  const { findings, stats } = await checkDeadLinksDetailed(
+    '[missing](missing.md) [remote](https://example.com)',
+    {
+      sourceFile,
+      checkRemote: false,
+      requestFn: () => {
+        throw new Error('remote request must not run');
+      }
+    }
+  );
+
+  assert.equal(findings.some((finding) => finding.code === 'dead-link'), true);
+  assert.equal(findings.some((finding) => finding.message.includes('example.com')), false);
+  assert.equal(stats.remoteLinksChecked, 0);
+});
+
+test('v2 directory selection is deterministically sorted', async (t) => {
+  const cwd = makeTempDir(t);
+  for (const name of ['zeta.md', 'alpha.md', 'mike.md', 'bravo.md']) {
+    fs.writeFileSync(path.join(cwd, name), `# ${name}\n`, 'utf8');
+  }
+
+  const result = await check({ cwd, paths: ['.'] });
+  assert.deepEqual(result.files.map((file) => file.path), [
+    'alpha.md',
+    'bravo.md',
+    'mike.md',
+    'zeta.md'
+  ]);
+});
+
+test('v2 machine formats emit one document with no human logs', (t) => {
+  const cwd = makeTempDir(t);
+  fs.writeFileSync(path.join(cwd, 'doc.md'), '# Clean\n', 'utf8');
+
+  for (const format of ['json', 'sarif', 'junit']) {
+    const run = runCli(['check', 'doc.md', '--format', format], cwd);
+    assert.equal(run.status, 0, `${format}: ${run.stderr}`);
+    assert.equal(run.stderr, '', format);
+    if (format === 'junit') {
+      assert.match(run.stdout, /^<\?xml version="1\.0" encoding="UTF-8"\?>\n<testsuite/);
+      assert.equal((run.stdout.match(/<\?xml/g) || []).length, 1);
+    } else {
+      assert.doesNotThrow(() => JSON.parse(run.stdout), format);
+      assert.equal(run.stdout.trim().split('\nDoclify Guardrail').length, 1);
+    }
+  }
+});
+
+test('v2 CLI flushes a large complete machine document before exiting', (t) => {
+  const cwd = makeTempDir(t);
+  const placeholders = Array.from({ length: 1500 }, (_, index) => `TODO item ${index + 1}`).join('\n');
+  fs.writeFileSync(path.join(cwd, 'many.md'), `# Many\n\n${placeholders}\n`, 'utf8');
+
+  const run = runCli(['check', 'many.md', '--format', 'json'], cwd);
+  assert.equal(run.status, 0, run.stderr);
+  assert.equal(run.stderr, '');
+  assert.ok(run.stdout.length > 65_536, `expected output larger than a pipe buffer, got ${run.stdout.length}`);
+  const result = JSON.parse(run.stdout);
+  assert.equal(result.findings.length, result.summary.advisory);
+  assert.ok(result.findings.length >= 1500);
+});
+
+test('v2 --output is explicit and contained in the workspace', (t) => {
+  const cwd = makeTempDir(t);
+  fs.writeFileSync(path.join(cwd, 'doc.md'), '# Clean\n', 'utf8');
+
+  const inside = runCli(['check', 'doc.md', '--format', 'json', '--output', 'out/result.json'], cwd);
+  assert.equal(inside.status, 0, inside.stderr);
+  assert.equal(inside.stdout, '');
+  assert.equal(inside.stderr, '');
+  assert.equal(JSON.parse(fs.readFileSync(path.join(cwd, 'out', 'result.json'), 'utf8')).schemaVersion, 3);
+
+  const outside = runCli(['check', 'doc.md', '--format', 'json', '--output', '../result.json'], cwd);
+  assert.equal(outside.status, 2);
+  assert.equal(outside.stdout, '');
+  assert.match(outside.stderr, /^output-outside-workspace:/);
+});
+
+test('v2 --output cannot overwrite a scanned file through a symlink', (t) => {
+  const cwd = makeTempDir(t);
+  const documentPath = path.join(cwd, 'doc.md');
+  fs.writeFileSync(documentPath, '# Clean\n', 'utf8');
+  fs.symlinkSync(documentPath, path.join(cwd, 'result.json'));
+
+  const run = runCli(['check', 'doc.md', '--format', 'json', '--output', 'result.json'], cwd);
+  assert.equal(run.status, 2);
+  assert.equal(run.stdout, '');
+  assert.match(run.stderr, /^output-overwrites-input:/);
+  assert.equal(fs.readFileSync(documentPath, 'utf8'), '# Clean\n');
+});
+
+test('v2 paths cannot cross the workspace through symlinks', async (t) => {
+  const cwd = makeTempDir(t);
+  const outside = makeTempDir(t);
+  fs.mkdirSync(path.join(cwd, 'docs'));
+  fs.mkdirSync(path.join(cwd, 'shared-dir'));
+  fs.writeFileSync(path.join(cwd, 'doc.md'), '# Clean\n', 'utf8');
+  fs.writeFileSync(path.join(cwd, 'shared.md'), 'Body without a heading.\n', 'utf8');
+  fs.writeFileSync(path.join(cwd, 'shared-dir', 'note.md'), '# Shared\n', 'utf8');
+  fs.writeFileSync(path.join(outside, 'outside.md'), '# Outside\n', 'utf8');
+  fs.symlinkSync('../shared.md', path.join(cwd, 'docs', 'linked.md'));
+  fs.symlinkSync(outside, path.join(cwd, 'outside-dir'));
+  fs.symlinkSync(path.join(outside, 'outside.md'), path.join(cwd, 'outside.md'));
+
+  const internal = await check({ cwd, paths: ['docs'] });
+  assert.equal(internal.complete, true);
+  assert.deepEqual(internal.files.map((file) => file.path), ['docs/linked.md']);
+  assert.equal(internal.findings.length, 1);
+  fs.symlinkSync('../shared-dir', path.join(cwd, 'docs', 'linked-dir'));
+  fs.symlinkSync('./missing.txt', path.join(cwd, 'docs', 'broken.txt'));
+  fs.symlinkSync('./gone.md', path.join(cwd, 'docs', 'broken.md'));
+
+  const lexicalDirectory = await check({ cwd, paths: ['docs'], exclude: ['docs/broken.md'] });
+  assert.equal(lexicalDirectory.complete, true);
+  assert.deepEqual(lexicalDirectory.files.map((file) => file.path), ['docs/linked.md']);
+
+  const brokenMarkdown = await check({ cwd, paths: ['docs'] });
+  assert.equal(brokenMarkdown.complete, false);
+  assert.equal(
+    brokenMarkdown.diagnostics.some(
+      (diagnostic) => diagnostic.code === 'target-unreadable' && diagnostic.path === 'docs/broken.md'
+    ),
+    true
+  );
+
+  const output = runCli([
+    'check',
+    'doc.md',
+    '--format',
+    'json',
+    '--output',
+    'outside-dir/new/result.json'
+  ], cwd);
+  assert.equal(output.status, 2);
+  assert.equal(output.stdout, '');
+  assert.match(output.stderr, /^output-outside-workspace:/);
+  assert.equal(fs.existsSync(path.join(outside, 'new', 'result.json')), false);
+
+  await assert.rejects(
+    check({ cwd, paths: ['outside.md'] }),
+    (error) => error?.name === 'DoclifyUsageError' && error?.code === 'target-outside-workspace'
+  );
+
+  const linkedDirectory = await check({
+    cwd,
+    paths: ['.'],
+    exclude: ['outside-dir', 'outside.md', 'docs/broken.md']
+  });
+  assert.equal(linkedDirectory.complete, true);
+  assert.equal(linkedDirectory.files.some((file) => file.path === 'shared-dir/note.md'), true);
+  assert.equal(linkedDirectory.files.some((file) => file.path.startsWith('docs/linked-dir/')), false);
+});
+
+test('v2 glob prefixes cannot escape the workspace', async (t) => {
+  const cwd = makeTempDir(t);
+  await assert.rejects(
+    check({ cwd, paths: ['../**/*.md'] }),
+    (error) => error?.name === 'DoclifyUsageError' && error?.code === 'target-outside-workspace'
+  );
+});
+
+test('v2 changed grammar requires exactly one selector', (t) => {
+  const cwd = makeTempDir(t);
+  const missing = runCli(['changed', '--format', 'json'], cwd);
+  assert.equal(missing.status, 2);
+  assert.match(missing.stderr, /exactly one of --base or --staged/);
+
+  const both = runCli(['changed', '--base', 'HEAD', '--staged', '--format', 'json'], cwd);
+  assert.equal(both.status, 2);
+  assert.match(both.stderr, /exactly one of --base or --staged/);
+});
+
+test('v2 changed scans a root-level Git diff through the shared result model', (t) => {
+  const cwd = makeTempDir(t);
+  const git = (...args) => spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.equal(git('init', '-q').status, 0);
+  assert.equal(git('config', 'user.email', 'fixture@example.invalid').status, 0);
+  assert.equal(git('config', 'user.name', 'Fixture').status, 0);
+  fs.writeFileSync(path.join(cwd, 'doc.md'), '# Original\n', 'utf8');
+  assert.equal(git('add', 'doc.md').status, 0);
+  assert.equal(git('commit', '-qm', 'fixture').status, 0);
+  fs.writeFileSync(path.join(cwd, 'doc.md'), '# Changed\n', 'utf8');
+
+  const run = runCli(['changed', '--base', 'HEAD', '--format', 'json', '--all'], cwd);
+  assert.equal(run.status, 0, run.stderr);
+  assert.equal(run.stderr, '');
+  const result = JSON.parse(run.stdout);
+  assert.equal(result.schemaVersion, 3);
+  assert.equal(result.command, 'changed');
+  assert.deepEqual(result.files.map((file) => file.path), ['doc.md']);
+});

--- a/test/v2-contract.test.mjs
+++ b/test/v2-contract.test.mjs
@@ -27,8 +27,12 @@ function runCli(args, cwd) {
     encoding: 'utf8',
     env: {
       LANG: 'C',
+      LC_ALL: 'C',
       NO_COLOR: '1',
-      PATH: process.env.PATH || ''
+      PATH: process.env.PATH || '',
+      TMPDIR: process.env.TMPDIR || '',
+      TMP: process.env.TMP || '',
+      TEMP: process.env.TEMP || ''
     }
   });
 }

--- a/test/v2-contract.test.mjs
+++ b/test/v2-contract.test.mjs
@@ -201,7 +201,7 @@ test('v2 partial scan returns a structured incomplete result and exit 1', async 
   assert.equal(apiResult.diagnostics[0].code, 'file-unreadable');
   assert.equal(apiResult.files.find((file) => file.path === 'missing.md').findings, null);
   assert.equal(cli.status, 1, cli.stderr);
-  assert.equal(cli.stderr, '');
+  assert.match(cli.stderr, /^missing\.md: error \[file-unreadable\]/);
   assert.deepEqual(JSON.parse(cli.stdout), apiResult);
 });
 
@@ -210,7 +210,7 @@ test('v2 unreadable targets stay structured while empty scans and invalid usage 
 
   const missing = runCli(['check', 'missing.md', '--format', 'json'], cwd);
   assert.equal(missing.status, 1, missing.stderr);
-  assert.equal(missing.stderr, '');
+  assert.match(missing.stderr, /^missing\.md: error \[file-unreadable\]/);
   const missingResult = JSON.parse(missing.stdout);
   assert.equal(missingResult.status, 'incomplete');
   assert.equal(missingResult.files[0].scanned, false);
@@ -287,7 +287,7 @@ test('v2 suppression metadata follows checker fence and rule-list semantics', as
 test('v2 local link checks remain offline unless external links are explicit', async (t) => {
   const cwd = makeTempDir(t);
   const sourceFile = path.join(cwd, 'doc.md');
-  const { findings, stats } = await checkDeadLinksDetailed(
+  const { diagnostics, findings, stats } = await checkDeadLinksDetailed(
     '[missing](missing.md) [remote](https://example.com)',
     {
       sourceFile,
@@ -298,9 +298,28 @@ test('v2 local link checks remain offline unless external links are explicit', a
     }
   );
 
+  assert.equal(diagnostics.some((diagnostic) => diagnostic.code === 'dead-link'), true);
   assert.equal(findings.some((finding) => finding.code === 'dead-link'), true);
   assert.equal(findings.some((finding) => finding.message.includes('example.com')), false);
   assert.equal(stats.remoteLinksChecked, 0);
+});
+
+test('v2 local links never inspect outside the selected workspace', async (t) => {
+  const outer = makeTempDir(t);
+  const cwd = path.join(outer, 'workspace');
+  fs.mkdirSync(cwd);
+  const outside = path.join(outer, 'outside.md');
+  fs.writeFileSync(outside, '# Outside\n', 'utf8');
+  fs.writeFileSync(path.join(cwd, 'doc.md'), '# Doc\n\n[outside](../outside.md)\n[missing](missing.md)\n', 'utf8');
+
+  const result = await check({ cwd, paths: ['doc.md'] });
+  const cli = runCli(['check', 'doc.md', '--format', 'json'], cwd);
+  assert.equal(result.status, 'incomplete');
+  assert.deepEqual(result.diagnostics.map((diagnostic) => diagnostic.code), ['dead-link', 'link-outside-workspace']);
+  assert.equal(cli.status, 1);
+  assert.deepEqual(JSON.parse(cli.stdout), result);
+  assert.match(cli.stderr, /doc\.md: error \[dead-link\]/);
+  assert.match(cli.stderr, /doc\.md: error \[link-outside-workspace\]/);
 });
 
 test('v2 directory selection is deterministically sorted', async (t) => {
@@ -371,6 +390,19 @@ test('v2 --output cannot overwrite a scanned file through a symlink', (t) => {
   const documentPath = path.join(cwd, 'doc.md');
   fs.writeFileSync(documentPath, '# Clean\n', 'utf8');
   fs.symlinkSync(documentPath, path.join(cwd, 'result.json'));
+
+  const run = runCli(['check', 'doc.md', '--format', 'json', '--output', 'result.json'], cwd);
+  assert.equal(run.status, 2);
+  assert.equal(run.stdout, '');
+  assert.match(run.stderr, /^output-overwrites-input:/);
+  assert.equal(fs.readFileSync(documentPath, 'utf8'), '# Clean\n');
+});
+
+test('v2 --output cannot overwrite a scanned file through a hard link', (t) => {
+  const cwd = makeTempDir(t);
+  const documentPath = path.join(cwd, 'doc.md');
+  fs.writeFileSync(documentPath, '# Clean\n', 'utf8');
+  fs.linkSync(documentPath, path.join(cwd, 'result.json'));
 
   const run = runCli(['check', 'doc.md', '--format', 'json', '--output', 'result.json'], cwd);
   assert.equal(run.status, 2);

--- a/test/v2-git-config.test.mjs
+++ b/test/v2-git-config.test.mjs
@@ -1,0 +1,494 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { check } from '../src/api.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(ROOT, 'src', 'index.mjs');
+
+function makeTempDir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doclify-v2-git-config-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    env: options.env || process.env
+  });
+}
+
+function runCli(args, cwd, env = {}) {
+  return run(process.execPath, [CLI, ...args], {
+    cwd,
+    env: {
+      LANG: 'C',
+      LC_ALL: 'C',
+      NO_COLOR: '1',
+      PATH: process.env.PATH || '',
+      ...env
+    }
+  });
+}
+
+function git(cwd, ...args) {
+  return run('git', args, { cwd });
+}
+
+function initRepository(t) {
+  const root = makeTempDir(t);
+  assert.equal(git(root, 'init', '-q').status, 0);
+  assert.equal(git(root, 'config', 'user.email', 'fixture@example.invalid').status, 0);
+  assert.equal(git(root, 'config', 'user.name', 'Fixture').status, 0);
+  return root;
+}
+
+function commitAll(root, message = 'fixture') {
+  assert.equal(git(root, 'add', '.').status, 0);
+  assert.equal(git(root, 'commit', '-qm', message).status, 0);
+}
+
+test('v2 changed is root-correct and quote-safe from repository subdirectories', (t) => {
+  const root = initRepository(t);
+  const docs = path.join(root, 'docs');
+  fs.mkdirSync(docs);
+  fs.writeFileSync(path.join(root, 'README.md'), '# Original\n', 'utf8');
+  fs.writeFileSync(path.join(docs, 'guida più.md'), '# Original\n', 'utf8');
+  fs.writeFileSync(path.join(docs, 'space name.mdx'), '# Original\n', 'utf8');
+  fs.writeFileSync(path.join(docs, 'tab\tname.md'), '# Original\n', 'utf8');
+  fs.writeFileSync(path.join(docs, 'line\nbreak.md'), '# Original\n', 'utf8');
+  commitAll(root);
+
+  fs.writeFileSync(path.join(root, 'README.md'), '# Changed\n', 'utf8');
+  fs.writeFileSync(path.join(docs, 'guida più.md'), '# Changed\n', 'utf8');
+  fs.writeFileSync(path.join(docs, 'space name.mdx'), '# Changed\n', 'utf8');
+  fs.writeFileSync(path.join(docs, 'tab\tname.md'), '# Changed\n', 'utf8');
+  fs.writeFileSync(path.join(docs, 'line\nbreak.md'), '# Changed\n', 'utf8');
+
+  const rootBase = runCli(['changed', '--base', 'HEAD', '--format', 'json'], root);
+  const subdirBase = runCli(['changed', '--base', 'HEAD', '--format', 'json'], docs);
+  assert.equal(rootBase.status, 0, rootBase.stderr);
+  assert.equal(subdirBase.status, 0, subdirBase.stderr);
+  assert.equal(subdirBase.stdout, rootBase.stdout);
+  assert.deepEqual(new Set(JSON.parse(rootBase.stdout).files.map((file) => file.path)), new Set([
+    'README.md',
+    'docs/guida più.md',
+    'docs/space name.mdx',
+    'docs/tab\tname.md',
+    'docs/line\nbreak.md'
+  ]));
+
+  assert.equal(git(root, 'add', '.').status, 0);
+  const rootStaged = runCli(['changed', '--staged', '--format', 'json'], root);
+  const subdirStaged = runCli(['changed', '--staged', '--format', 'json'], docs);
+  assert.equal(rootStaged.status, 0, rootStaged.stderr);
+  assert.equal(subdirStaged.status, 0, subdirStaged.stderr);
+  assert.equal(subdirStaged.stdout, rootStaged.stdout);
+});
+
+test('v2 changed scans rename destinations and excludes deletions and untracked files', (t) => {
+  const root = initRepository(t);
+  fs.writeFileSync(path.join(root, '.gitignore'), 'ignored.md\n', 'utf8');
+  fs.writeFileSync(path.join(root, 'old.md'), '# Old\n', 'utf8');
+  fs.writeFileSync(path.join(root, 'deleted.md'), '# Delete\n', 'utf8');
+  commitAll(root);
+
+  assert.equal(git(root, 'mv', 'old.md', 'renamed più.md').status, 0);
+  assert.equal(git(root, 'rm', '-q', 'deleted.md').status, 0);
+  fs.writeFileSync(path.join(root, 'untracked.md'), '# Untracked\n', 'utf8');
+  fs.writeFileSync(path.join(root, 'ignored.md'), '# Ignored\n', 'utf8');
+
+  for (const selector of [['--base', 'HEAD'], ['--staged']]) {
+    const result = runCli(['changed', ...selector, '--format', 'json'], root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout).files.map((file) => file.path), ['renamed più.md']);
+  }
+});
+
+test('v2 changed CLI and API share selection and reject invalid API selectors', async (t) => {
+  const root = initRepository(t);
+  fs.writeFileSync(path.join(root, 'doc.md'), '# Original\n', 'utf8');
+  commitAll(root);
+  fs.writeFileSync(path.join(root, 'doc.md'), '# Changed\n', 'utf8');
+
+  const cli = runCli(['changed', '--base', 'HEAD', '--format', 'json'], root);
+  const api = await check({ command: 'changed', changed: { base: 'HEAD' }, cwd: root });
+  assert.equal(cli.status, 0, cli.stderr);
+  assert.deepEqual(JSON.parse(cli.stdout), api);
+
+  for (const changed of [{}, { base: 'HEAD', staged: true }, { base: '' }, { base: '', staged: true }, { staged: false }]) {
+    await assert.rejects(
+      check({ command: 'changed', changed, cwd: root }),
+      (error) => error?.code === 'invalid-changed-selector'
+    );
+  }
+});
+
+test('v2 Git failure modes are stable while check works without Git', async (t) => {
+  const outside = makeTempDir(t);
+  fs.writeFileSync(path.join(outside, 'doc.md'), '# Clean\n', 'utf8');
+
+  const checked = await check({ cwd: outside, paths: ['doc.md'] });
+  assert.equal(checked.status, 'pass');
+
+  const noRepository = runCli(['changed', '--base', 'HEAD'], outside);
+  assert.equal(noRepository.status, 2);
+  assert.match(noRepository.stderr, /^not-a-git-repository:/);
+
+  const noGit = runCli(['changed', '--base', 'HEAD'], outside, { PATH: '' });
+  assert.equal(noGit.status, 2);
+  assert.match(noGit.stderr, /^git-unavailable:/);
+
+  const root = initRepository(t);
+  fs.writeFileSync(path.join(root, 'doc.md'), '# Clean\n', 'utf8');
+  commitAll(root);
+  const unknown = runCli(['changed', '--base', 'does-not-exist'], root);
+  assert.equal(unknown.status, 2);
+  assert.match(unknown.stderr, /^unknown-base-ref:/);
+});
+
+test('v2 automatic config is hierarchical, relative to each config, and consistent by cwd', async (t) => {
+  const root = initRepository(t);
+  const docs = path.join(root, 'docs');
+  const drafts = path.join(docs, 'drafts');
+  const publicDir = path.join(docs, 'public');
+  fs.mkdirSync(drafts, { recursive: true });
+  fs.mkdirSync(publicDir);
+  fs.writeFileSync(path.join(root, '.doclify-guardrail.json'), JSON.stringify({
+    ignoreRules: ['placeholder'],
+    linkAllowList: ['https://root.example']
+  }), 'utf8');
+  fs.writeFileSync(path.join(docs, '.doclify-guardrail.json'), JSON.stringify({
+    ignoreRules: ['img-alt'],
+    exclude: ['drafts'],
+    siteRoot: 'public',
+    linkAllowList: ['https://docs.example']
+  }), 'utf8');
+  fs.writeFileSync(path.join(docs, 'guide.md'), '# Guide\n\nTODO\n\n![](image.png)\n\n[ok](/existing.md)\n', 'utf8');
+  fs.writeFileSync(path.join(docs, 'image.png'), '', 'utf8');
+  fs.writeFileSync(path.join(drafts, 'ignored.md'), '# Draft\n', 'utf8');
+  fs.writeFileSync(path.join(publicDir, 'existing.md'), '# Existing\n', 'utf8');
+  commitAll(root);
+
+  const fromRoot = await check({ cwd: root, paths: ['docs/guide.md'] });
+  const fromDocs = await check({ cwd: docs, paths: ['guide.md'] });
+  assert.equal(fromRoot.status, 'pass');
+  assert.equal(fromDocs.status, 'pass');
+  assert.deepEqual(fromRoot.findings, []);
+  assert.deepEqual(fromDocs.findings, []);
+
+  const recursive = await check({ cwd: root, paths: ['.'] });
+  assert.equal(recursive.files.some((file) => file.path === 'docs/drafts/ignored.md'), false);
+});
+
+test('v2 CLI and API overrides apply after hierarchical configuration', async (t) => {
+  const root = initRepository(t);
+  fs.writeFileSync(path.join(root, '.doclify-guardrail.json'), JSON.stringify({
+    ignoreRules: ['placeholder']
+  }), 'utf8');
+  fs.writeFileSync(path.join(root, 'doc.md'), '# Guide\n\nTODO\n\n![](image.png)\n', 'utf8');
+  fs.writeFileSync(path.join(root, 'image.png'), '', 'utf8');
+  commitAll(root);
+
+  const api = await check({ cwd: root, paths: ['doc.md'], ignoreRules: ['img-alt'] });
+  const cli = runCli(['check', 'doc.md', '--ignore-rules', 'img-alt', '--format', 'json'], root);
+  assert.equal(cli.status, 0, cli.stderr);
+  assert.deepEqual(JSON.parse(cli.stdout), api);
+  assert.deepEqual(api.findings, []);
+});
+
+test('v2 explicit config is one contained file and disables implicit hierarchy', async (t) => {
+  const root = initRepository(t);
+  const docs = path.join(root, 'docs');
+  fs.mkdirSync(docs);
+  fs.writeFileSync(path.join(root, 'explicit.json'), JSON.stringify({ ignoreRules: ['placeholder'] }), 'utf8');
+  fs.writeFileSync(path.join(root, '.doclify-guardrail.json'), JSON.stringify({ unknownRootKey: true }), 'utf8');
+  fs.writeFileSync(path.join(docs, '.doclify-guardrail.json'), JSON.stringify({ unknownNestedKey: true }), 'utf8');
+  fs.writeFileSync(path.join(docs, 'doc.md'), '# Guide\n\nTODO\n', 'utf8');
+  commitAll(root);
+
+  const api = await check({ cwd: root, paths: ['docs/doc.md'], config: 'explicit.json' });
+  const cli = runCli(['check', 'docs/doc.md', '--config', 'explicit.json', '--format', 'json'], root);
+  assert.equal(cli.status, 0, cli.stderr);
+  assert.deepEqual(JSON.parse(cli.stdout), api);
+  assert.deepEqual(api.findings, []);
+
+  const subdirectoryApi = await check({ cwd: docs, paths: ['doc.md'], config: '../explicit.json' });
+  const subdirectoryCli = runCli([
+    'check',
+    'doc.md',
+    '--config',
+    '../explicit.json',
+    '--format',
+    'json'
+  ], docs);
+  assert.equal(subdirectoryCli.status, 0, subdirectoryCli.stderr);
+  assert.deepEqual(JSON.parse(subdirectoryCli.stdout), subdirectoryApi);
+  assert.deepEqual(subdirectoryApi.findings, []);
+
+  fs.writeFileSync(path.join(docs, 'doc.md'), '# Guide\n\nTODO changed\n', 'utf8');
+  const changedApi = await check({
+    command: 'changed',
+    changed: { base: 'HEAD' },
+    cwd: docs,
+    config: '../explicit.json'
+  });
+  const changedCli = runCli([
+    'changed',
+    '--base',
+    'HEAD',
+    '--config',
+    '../explicit.json',
+    '--format',
+    'json'
+  ], docs);
+  assert.equal(changedCli.status, 0, changedCli.stderr);
+  assert.deepEqual(JSON.parse(changedCli.stdout), changedApi);
+  assert.deepEqual(changedApi.files.map((file) => file.path), ['docs/doc.md']);
+  assert.deepEqual(changedApi.findings, []);
+
+  await assert.rejects(
+    check({ cwd: root, paths: ['docs/doc.md'], config: 'missing.json' }),
+    (error) => error?.code === 'config-not-found'
+  );
+
+  const outside = makeTempDir(t);
+  const outsideConfig = path.join(outside, 'config.json');
+  fs.writeFileSync(outsideConfig, '{}', 'utf8');
+  fs.symlinkSync(outsideConfig, path.join(root, 'linked-config.json'));
+  await assert.rejects(
+    check({ cwd: root, paths: ['docs/doc.md'], config: 'linked-config.json' }),
+    (error) => error?.code === 'config-outside-workspace'
+  );
+});
+
+test('v2 config rejects removed, unknown, malformed, and invalid keys with stable codes', async (t) => {
+  const cases = [
+    [{ strict: true }, 'config-removed-key'],
+    [{ checkLinks: true }, 'config-removed-key'],
+    [{ externalLinks: true }, 'config-unknown-key'],
+    [{ futureOption: true }, 'config-unknown-key'],
+    [{ ignoreRules: 'placeholder' }, 'config-invalid'],
+    [{ linkTimeoutMs: 0 }, 'config-invalid']
+  ];
+
+  for (const [config, code] of cases) {
+    const root = initRepository(t);
+    fs.writeFileSync(path.join(root, '.doclify-guardrail.json'), JSON.stringify(config), 'utf8');
+    fs.writeFileSync(path.join(root, 'doc.md'), '# Clean\n', 'utf8');
+    await assert.rejects(
+      check({ cwd: root, paths: ['doc.md'] }),
+      (error) => error?.code === code,
+      JSON.stringify(config)
+    );
+    const cli = runCli(['check', 'doc.md'], root);
+    assert.equal(cli.status, 2);
+    assert.match(cli.stderr, new RegExp(`^${code}:`));
+  }
+
+  const malformed = initRepository(t);
+  fs.writeFileSync(path.join(malformed, '.doclify-guardrail.json'), '{', 'utf8');
+  fs.writeFileSync(path.join(malformed, 'doc.md'), '# Clean\n', 'utf8');
+  await assert.rejects(
+    check({ cwd: malformed, paths: ['doc.md'] }),
+    (error) => error?.code === 'config-invalid'
+  );
+});
+
+test('v2 network access requires an explicit CLI or API option', async (t) => {
+  const root = initRepository(t);
+  fs.writeFileSync(path.join(root, 'doc.md'), '# Clean\n', 'utf8');
+  fs.writeFileSync(path.join(root, '.doclify-guardrail.json'), JSON.stringify({
+    linkTimeoutMs: 25,
+    linkConcurrency: 1,
+    linkAllowList: ['https://example.invalid']
+  }), 'utf8');
+  commitAll(root);
+
+  assert.equal((await check({ cwd: root, paths: ['doc.md'] })).status, 'pass');
+  assert.equal((await check({ cwd: root, paths: ['doc.md'], externalLinks: true })).status, 'pass');
+  await assert.rejects(
+    check({ cwd: root, paths: ['doc.md'], links: { timeoutMs: 25 } }),
+    (error) => error?.code === 'invalid-link-options'
+  );
+  const cli = runCli(['check', 'doc.md', '--link-timeout-ms', '25'], root);
+  assert.equal(cli.status, 2);
+  assert.match(cli.stderr, /^invalid-link-options:/);
+});
+
+test('v2 automatic config never reads above the Git root or non-Git workspace', async (t) => {
+  const parent = makeTempDir(t);
+  fs.writeFileSync(path.join(parent, '.doclify-guardrail.json'), JSON.stringify({ inheritedByMistake: true }), 'utf8');
+
+  const repository = path.join(parent, 'repo');
+  fs.mkdirSync(repository);
+  assert.equal(git(repository, 'init', '-q').status, 0);
+  assert.equal(git(repository, 'config', 'user.email', 'fixture@example.invalid').status, 0);
+  assert.equal(git(repository, 'config', 'user.name', 'Fixture').status, 0);
+  fs.writeFileSync(path.join(repository, 'doc.md'), '# Clean\n', 'utf8');
+  commitAll(repository);
+  assert.equal((await check({ cwd: repository, paths: ['doc.md'] })).status, 'pass');
+
+  const standalone = path.join(parent, 'standalone');
+  fs.mkdirSync(standalone);
+  fs.writeFileSync(path.join(standalone, 'doc.md'), '# Clean\n', 'utf8');
+  assert.equal((await check({ cwd: standalone, paths: ['doc.md'] })).status, 'pass');
+});
+
+test('v2 exclusions prune unreadable directories before nested config discovery', async (t) => {
+  const root = initRepository(t);
+  const restricted = path.join(root, 'restricted');
+  fs.mkdirSync(restricted);
+  fs.writeFileSync(path.join(root, 'doc.md'), '# Clean\n', 'utf8');
+  fs.writeFileSync(path.join(restricted, 'hidden.md'), '# Hidden\n', 'utf8');
+  commitAll(root);
+  fs.chmodSync(restricted, 0o000);
+  try {
+    const direct = await check({ cwd: root, paths: ['restricted/hidden.md'] });
+    assert.equal(direct.complete, false);
+    assert.deepEqual(direct.files.map((file) => ({ path: file.path, scanned: file.scanned })), [
+      { path: 'restricted/hidden.md', scanned: false }
+    ]);
+    assert.equal(direct.diagnostics.some((item) => item.code === 'file-unreadable'), true);
+    assert.equal(direct.diagnostics.some((item) => item.code === 'target-outside-workspace'), false);
+
+    const incomplete = await check({ cwd: root, paths: ['.'] });
+    assert.equal(incomplete.complete, false);
+    assert.equal(incomplete.diagnostics.some((item) => item.code === 'directory-unreadable'), true);
+
+    const excludedByOption = await check({ cwd: root, paths: ['.'], exclude: ['restricted'] });
+    assert.equal(excludedByOption.complete, true);
+    assert.deepEqual(excludedByOption.files.map((file) => file.path), ['doc.md']);
+
+    fs.writeFileSync(path.join(root, '.doclify-guardrail.json'), JSON.stringify({ exclude: ['restricted'] }), 'utf8');
+    const excluded = await check({ cwd: root, paths: ['.'] });
+    assert.equal(excluded.complete, true);
+    assert.deepEqual(excluded.files.map((file) => file.path), ['doc.md']);
+  } finally {
+    fs.chmodSync(restricted, 0o700);
+  }
+});
+
+test('v2 reports unreadable discovered config without misclassifying it as malformed JSON', async (t) => {
+  const root = initRepository(t);
+  const configPath = path.join(root, '.doclify-guardrail.json');
+  fs.writeFileSync(configPath, '{}\n', 'utf8');
+  fs.writeFileSync(path.join(root, 'doc.md'), '# Clean\n', 'utf8');
+  commitAll(root);
+  fs.chmodSync(configPath, 0o000);
+  try {
+    await assert.rejects(
+      check({ cwd: root, paths: ['doc.md'] }),
+      (error) => error?.code === 'config-invalid'
+        && /cannot be read/.test(error.message)
+        && !/valid JSON/.test(error.message)
+    );
+
+    const cli = runCli(['check', 'doc.md'], root);
+    assert.equal(cli.status, 2);
+    assert.match(cli.stderr, /^config-invalid: Configuration file cannot be read:/);
+  } finally {
+    fs.chmodSync(configPath, 0o600);
+  }
+});
+
+test('v2 repository siteRoot is stable when check runs from a subdirectory', async (t) => {
+  const root = initRepository(t);
+  const docs = path.join(root, 'docs');
+  const publicDir = path.join(root, 'public');
+  fs.mkdirSync(docs);
+  fs.mkdirSync(publicDir);
+  fs.writeFileSync(path.join(root, '.doclify-guardrail.json'), JSON.stringify({ siteRoot: 'public' }), 'utf8');
+  fs.writeFileSync(path.join(docs, 'guide.md'), '# Guide\n\n[home](/existing.md)\n', 'utf8');
+  fs.writeFileSync(path.join(publicDir, 'existing.md'), '# Existing\n', 'utf8');
+  commitAll(root);
+
+  const fromRoot = await check({ cwd: root, paths: ['docs/guide.md'] });
+  const fromDocs = await check({ cwd: docs, paths: ['guide.md'] });
+  assert.equal(fromRoot.status, 'pass');
+  assert.equal(fromDocs.status, 'pass');
+  assert.deepEqual(fromRoot.findings, []);
+  assert.deepEqual(fromDocs.findings, []);
+});
+
+test('v2 changed works from a linked worktree and its subdirectory', (t) => {
+  const main = initRepository(t);
+  fs.writeFileSync(path.join(main, 'doc.md'), '# Original\n', 'utf8');
+  commitAll(main);
+
+  const worktree = makeTempDir(t);
+  fs.rmdirSync(worktree);
+  assert.equal(git(main, 'worktree', 'add', '-q', '-b', 'fixture-worktree', worktree).status, 0);
+  t.after(() => {
+    git(main, 'worktree', 'remove', '--force', worktree);
+    git(main, 'branch', '-D', 'fixture-worktree');
+  });
+  const docs = path.join(worktree, 'docs');
+  fs.mkdirSync(docs);
+  fs.writeFileSync(path.join(worktree, 'doc.md'), '# Changed\n', 'utf8');
+
+  const rootRun = runCli(['changed', '--base', 'HEAD', '--format', 'json'], worktree);
+  const subdirRun = runCli(['changed', '--base', 'HEAD', '--format', 'json'], docs);
+  assert.equal(rootRun.status, 0, rootRun.stderr);
+  assert.equal(subdirRun.status, 0, subdirRun.stderr);
+  assert.equal(subdirRun.stdout, rootRun.stdout);
+});
+
+test('v2 Git discovery is constant per scan instead of per file', (t) => {
+  const root = initRepository(t);
+  for (let index = 0; index < 12; index += 1) {
+    fs.writeFileSync(path.join(root, `doc-${index}.md`), '# Original\n', 'utf8');
+  }
+  commitAll(root);
+  for (let index = 0; index < 12; index += 1) {
+    fs.writeFileSync(path.join(root, `doc-${index}.md`), '# Changed\n', 'utf8');
+  }
+
+  const wrapperDirectory = makeTempDir(t);
+  const logPath = path.join(wrapperDirectory, 'git-calls.log');
+  const realGit = (process.env.PATH || '')
+    .split(path.delimiter)
+    .map((directory) => path.join(directory, 'git'))
+    .find((candidate) => {
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+  assert.ok(realGit, 'git executable not found');
+  const wrapper = path.join(wrapperDirectory, 'git');
+  fs.writeFileSync(wrapper, `#!/usr/bin/env node
+const fs = require('node:fs');
+const { spawnSync } = require('node:child_process');
+fs.appendFileSync(process.env.DOCLIFY_GIT_CALL_LOG, process.argv.slice(2).join(' ') + '\\n');
+const result = spawnSync(process.env.DOCLIFY_REAL_GIT, process.argv.slice(2), { stdio: 'inherit', env: process.env });
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);
+`, 'utf8');
+  fs.chmodSync(wrapper, 0o755);
+  const instrumentedEnvironment = {
+    PATH: `${wrapperDirectory}${path.delimiter}${process.env.PATH || ''}`,
+    DOCLIFY_GIT_CALL_LOG: logPath,
+    DOCLIFY_REAL_GIT: realGit
+  };
+
+  const changed = runCli(['changed', '--base', 'HEAD', '--format', 'json'], root, instrumentedEnvironment);
+  assert.equal(changed.status, 0, changed.stderr);
+  assert.equal(JSON.parse(changed.stdout).files.length, 12);
+  assert.equal(fs.readFileSync(logPath, 'utf8').trim().split('\n').length, 2);
+
+  fs.writeFileSync(logPath, '', 'utf8');
+  const checked = runCli(['check', '.', '--format', 'json'], root, instrumentedEnvironment);
+  assert.equal(checked.status, 0, checked.stderr);
+  assert.equal(JSON.parse(checked.stdout).files.length, 12);
+  assert.equal(fs.readFileSync(logPath, 'utf8').trim().split('\n').length, 1);
+});

--- a/test/v2-git-config.test.mjs
+++ b/test/v2-git-config.test.mjs
@@ -157,6 +157,22 @@ test('v2 Git failure modes are stable while check works without Git', async (t) 
   assert.match(unknown.stderr, /^unknown-base-ref:/);
 });
 
+test('v2 changed disables repository-configured fsmonitor commands', (t) => {
+  const root = initRepository(t);
+  const marker = path.join(root, 'fsmonitor-ran');
+  const monitor = path.join(root, 'fsmonitor.mjs');
+  fs.writeFileSync(path.join(root, 'doc.md'), '# Original\n', 'utf8');
+  fs.writeFileSync(monitor, `import fs from 'node:fs'; fs.writeFileSync(${JSON.stringify(marker)}, 'ran');\n`, 'utf8');
+  fs.chmodSync(monitor, 0o755);
+  commitAll(root);
+  assert.equal(git(root, 'config', 'core.fsmonitor', `${process.execPath} ${monitor}`).status, 0);
+  fs.writeFileSync(path.join(root, 'doc.md'), '# Changed\n', 'utf8');
+
+  const changed = runCli(['changed', '--base', 'HEAD', '--format', 'json'], root);
+  assert.equal(changed.status, 0, changed.stderr);
+  assert.equal(fs.existsSync(marker), false);
+});
+
 test('v2 automatic config is hierarchical, relative to each config, and consistent by cwd', async (t) => {
   const root = initRepository(t);
   const docs = path.join(root, 'docs');

--- a/test/v2-git-config.test.mjs
+++ b/test/v2-git-config.test.mjs
@@ -33,6 +33,9 @@ function runCli(args, cwd, env = {}) {
       LC_ALL: 'C',
       NO_COLOR: '1',
       PATH: process.env.PATH || '',
+      TMPDIR: process.env.TMPDIR || '',
+      TMP: process.env.TMP || '',
+      TEMP: process.env.TEMP || '',
       ...env
     }
   });


### PR DESCRIPTION
## Perché

Introduce la fondazione verificabile della beta v2: contratti `check`/`changed`, selezione Git/config sicura e test isolati.

## Cosa cambia

- Risultati schema v3, render JSON/SARIF/JUnit/text e uscite stabili.
- Selezione changed root-correct, configurazione gerarchica e boundary filesystem/link/Git.
- Versione `2.0.0-beta.1`; Action v1 resta separata.
- Correzioni review: diagnosi JUnit, cache timeout, hard-link output e aggiornamento sicuro di `undici` nella Action.

## Come verificare

- `npm test` (324/324, worktree invariato)
- `npm run test:performance`
- `npm run docs:sync-check`
- `npm --prefix action run build` e `npm --prefix action audit --omit=dev --audit-level=high`
- `npm pack --dry-run --json`

## Rischi e rollback

È una beta pubblicata solo tramite `next`; `latest` e Action `@v1` non cambiano. Rollback: rimuovere il dist-tag `next` dalla versione beta senza modificare `latest`.