### PR TITLE
docs: close beta.3 follow-up gaps

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -87,7 +87,8 @@ jobs:
         run: npm run test:labeled
       - name: Test controlled local network behavior
         run: npm run test:network
-      - name: Run 300-document performance profile
+      # The reviewed tolerance is deliberately broad: this catches only macroscopic regressions.
+      - name: Reject catastrophic performance regressions
         run: npm run test:performance
       - name: Verify docs sync
         run: npm run docs:sync-check

--- a/.github/workflows/reliability.yml
+++ b/.github/workflows/reliability.yml
@@ -62,5 +62,6 @@ jobs:
       - uses: actions/setup-node@v6.4.0
         with:
           node-version: '20'
-      - name: Enforce reviewed performance baseline
+      # The reviewed tolerance is deliberately broad: this catches only macroscopic regressions.
+      - name: Reject catastrophic performance regressions
         run: npm run test:performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased] — 2.0.0-beta.3 candidate
+
+### Added
+
+- added a v2 GitHub Action adapter that delegates to the same local CLI core, needs no token, and stays offline unless remote-link checks are explicitly enabled
+- added separate CI jobs for labeled correctness, controlled local-network behavior, and reviewed performance baselines
+- added a private-beta evidence protocol and portfolio copy draft without claiming adoption or publishing the draft
+
+### Changed
+
+- separated pure command parsing and help text from CLI runtime effects
+- made installed npm binary symlinks invoke the CLI entrypoint reliably
+- replaced the rule-noise fingerprint with 26 labeled cases and deterministic property coverage for paths, links, Markdown variants, and repository boundaries
+- reduced the Action dependency graph by removing the GitHub API and PR-comment path
+
+### Security
+
+- refuse report output that aliases scanned documents or resolves inside Git metadata
+- write repeatable non-Markdown reports through a temporary file and atomic rename without following an existing output symlink
+- block CGNAT and IPv4-compatible IPv6 private targets, and fail closed after 40 symbolic-link resolutions
+
+### Notes
+
+- the package remains `2.0.0-beta.2` until Lorenzo explicitly performs the npm publication step; this entry describes source merged to `main`, not a published release
+- the performance tolerance catches macroscopic regressions; it is not evidence of a tight performance target
+- private-beta task A4 still awaits qualifying real-user sessions
+
 ## [2.0.0-beta.2] - 2026-08-10
 
 ### Changed

--- a/PROJECT_STABILIZATION.md
+++ b/PROJECT_STABILIZATION.md
@@ -7,7 +7,6 @@ Updated: 2026-06-09
 ## Operating Context
 
 - Repository: `Elgabor/doclify-guardrail`
-- Local path: `/Users/lorenzoborgato/code/doclify-guardrail`
 - Goal: stabilize the repo, remove low-quality code, make CI pass, assess
   security, research real user pain points, and prepare a phased plan for a
   better version and future npm publish.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ as authored documentation.
 }
 ```
 
-`init --print` shows the smallest valid configuration. `init --write` creates
-that file only when it does not already exist.
+The example above shows optional fields. `init --print` shows the smallest
+valid configuration. `init --write` creates that file only when it does not
+already exist.
 
 ```sh
 npx doclify-guardrail init --print

--- a/scripts/check-docs-sync.mjs
+++ b/scripts/check-docs-sync.mjs
@@ -107,8 +107,8 @@ const checks = [
         pattern: /'bench\/baselines\/perf-300\.json'/
       },
       {
-        label: 'enforced performance profile',
-        pattern: /- name: Run 300-document performance profile\n\s+run: npm run test:performance/
+        label: 'explicit catastrophic performance regression gate',
+        pattern: /- name: Reject catastrophic performance regressions\n\s+run: npm run test:performance/
       },
       {
         label: 'labeled correctness transition gate',
@@ -121,6 +121,23 @@ const checks = [
       {
         label: 'README-only docs gate',
         pattern: /run: node \.\/src\/index\.mjs check README\.md --format compact/
+      }
+    ]
+  },
+  {
+    file: 'CHANGELOG.md',
+    expectations: [
+      {
+        label: 'unreleased beta.3 candidate entry',
+        pattern: /## \[Unreleased\] — 2\.0\.0-beta\.3 candidate/
+      },
+      {
+        label: 'unpublished candidate boundary',
+        pattern: /describes source merged to `main`, not a published release/
+      },
+      {
+        label: 'open private-beta gate',
+        pattern: /private-beta task A4 still awaits qualifying real-user sessions/
       }
     ]
   },

--- a/test/reliability-properties.test.mjs
+++ b/test/reliability-properties.test.mjs
@@ -61,7 +61,7 @@ test('Unicode paths and encoded anchors resolve identically with LF and CRLF', a
   }
 });
 
-test('workspace containment is stable for missing, Unicode, and symlinked paths', (t) => {
+test('workspace containment is stable for missing, Unicode, and symlinked paths', { skip: process.platform === 'win32' }, (t) => {
   const parent = temp(t);
   const workspace = path.join(parent, 'workspace');
   const outside = path.join(parent, 'outside');
@@ -86,7 +86,7 @@ test('workspace containment is stable for missing, Unicode, and symlinked paths'
   }
 });
 
-test('workspace containment fails closed for an excessive acyclic symlink chain', (t) => {
+test('workspace containment fails closed for an excessive acyclic symlink chain', { skip: process.platform === 'win32' }, (t) => {
   const workspace = temp(t);
   fs.mkdirSync(path.join(workspace, 'terminal'));
   for (let index = 40; index >= 0; index -= 1) {


### PR DESCRIPTION
## Result

Closes the post-merge gaps found by the beta.3 completion audit without changing package versions or release state.

- records the source candidate in an explicit Unreleased changelog entry
- states that the performance check is a broad catastrophic-regression ceiling, not tight performance evidence
- clarifies that the README configuration object shows optional fields while `init` remains minimal
- skips only symlink-dependent property tests on Windows
- removes the current-tree local home path from the public stabilization note

## Verification

- `npm test` — 59/59 plus labeled correctness 26/26 and 0 blocking false positives
- `npm run test:network` — pass
- `npm run test:performance` — pass when run in isolation; no baseline changed
- `npm run docs:sync-check` — pass
- targeted symlink property suite — 6/6 on macOS
- README and CHANGELOG Doclify scan — pass
- `npm pack --dry-run --json` — unchanged beta.2 package surface
- `git diff --check` and addition-only credential/path scan — pass

## Boundaries

A4 remains `AWAITING_REAL_USERS`; this PR adds no participant or adoption claim. Root stays `2.0.0-beta.2`, the private Action package stays `1.7.4`, and this PR creates no npm publication, tag, release, Action alias, or portfolio change.
