### PR TITLE
chore(release): prepare 2.0.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## [Unreleased] — 2.0.0-beta.3 candidate
+## [2.0.0-beta.3] - 2026-08-11
 
 ### Added
 
@@ -25,7 +25,7 @@ All notable changes to this project are documented in this file.
 
 ### Notes
 
-- the package remains `2.0.0-beta.2` until Lorenzo explicitly performs the npm publication step; this entry describes source merged to `main`, not a published release
+- this is an opt-in prerelease; `latest` remains on the stable v1 line
 - the performance tolerance catches macroscopic regressions; it is not evidence of a tight performance target
 - private-beta task A4 still awaits qualifying real-user sessions
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,7 +1,7 @@
 # Migrating to Doclify Guardrail v2
 
-`2.0.0-beta.2` is an opt-in prerelease on npm's `next` tag. `latest` remains
-the v1 line. The v2 core is local and read-only by default.
+`2.0.0-beta.3` is an opt-in prerelease for npm's `next` tag. `latest` remains
+on the v1 line. The v2 core is local and read-only by default.
 
 ## Command changes
 
@@ -77,12 +77,12 @@ silently accepted.
 | API `fix`, `score`, `RULE_CATALOG`, package-root import | Removed. |
 | config keys `strict`, `maxLineLength`, `checkLinks`, `checkFreshness`, `freshnessMaxDays`, `checkFrontmatter`, `checkInlineHtml`, `push`, `projectId` | Removed keys fail with `config-removed-key`. |
 | `.doclify-history.json`, `doclify-report.md`, `doclify-badge.svg`, `.doclify/` auth state | No v2 equivalent; remove them only after validating they are no longer used by your own workflow. |
-| Action inputs and outputs from `action@v1` | Stay on the frozen `Elgabor/doclify-guardrail/action@v1` contract, or migrate to the beta.3 candidate contract below after an immutable v2 reference is published. |
+| Action inputs and outputs from `action@v1` | Stay on the frozen `Elgabor/doclify-guardrail/action@v1` contract, or migrate to the beta.3 contract below after an immutable v2 reference is published. |
 
 MDX is classified as the limited `fragment` purpose unless configuration assigns
 another supported purpose. V2 does not evaluate MDX expressions.
 
-In beta.2 purpose is reported for every selected file. The high-signal integrity
+In beta.3 purpose is reported for every selected file. The high-signal integrity
 rules are shared by non-generated purposes; `generated` skips repository-command
 claims. This is classification, not a style preset.
 
@@ -91,7 +91,7 @@ claims. This is classification, not a style preset.
 `Elgabor/doclify-guardrail/action@v1` remains on its own v1 contract. This beta
 does not change, rebuild, or retag that Action.
 
-The source tree contains the forthcoming beta.3 Action adapter for local and
+This source release contains the beta.3 Action adapter for local and
 immutable-checkout validation. It maps `mode`, `path`, `base`, `staged`,
 `config`, `ignore-rules`, `exclude`, `site-root`, and the opt-in external-link
 settings directly to the v2 CLI. `mode: changed` requires exactly one of `base`

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ Doclify Guardrail checks Markdown and MDX documentation against facts that are
 already present in the repository. It runs locally, does not execute documented
 commands, and does not contact the network unless `--external-links` is passed.
 
-The npm prerelease is `2.0.0-beta.2`. This source tree also contains the
-forthcoming beta.3 Action adapter, but it is not a published release or tag.
-The supported v1 Action remains frozen at
-`Elgabor/doclify-guardrail/action@v1`.
+This source release is `2.0.0-beta.3`, an opt-in prerelease for npm's `next`
+tag. `latest` remains on the stable v1 line. The supported v1 Action remains
+frozen at `Elgabor/doclify-guardrail/action@v1`.
 
 ## Start
 
@@ -79,7 +78,7 @@ Every selected document has one purpose: `published`, `instructions`,
 `fragment`, `plan`, `changelog`, or `generated`. Configuration wins over the
 filename heuristic; the safe fallback is `fragment`. Purpose is included in
 the result for each file and does not turn generic formatting into a gate.
-In beta.2 the high-signal integrity rules are shared by non-generated purposes;
+In beta.3 the high-signal integrity rules are shared by non-generated purposes;
 `generated` skips repository-command claims so generated output is not treated
 as authored documentation.
 
@@ -123,9 +122,9 @@ node ./src/index.mjs check examples/evidence-demo/README.md --format compact
 node ./src/index.mjs check examples/evidence-demo/fixtures/README.broken.md --config examples/evidence-demo/.doclify-guardrail.json --format json
 ```
 
-## GitHub Action v2 candidate
+## GitHub Action v2 prerelease
 
-The beta.3 candidate is a thin adapter over the same CLI result. It requires no
+The beta.3 Action is a thin adapter over the same CLI result. It requires no
 token, has only `contents: read` permission, and stays offline unless
 `external-links: 'true'` is set. Until beta.3 has an immutable published
 reference, it can be verified from a checkout with the local Action path:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doclify-guardrail",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "type": "module",
   "description": "Deterministic, local, read-only documentation integrity checks for Markdown repositories.",
   "homepage": "https://github.com/Elgabor/doclify-guardrail#readme",

--- a/scripts/check-docs-sync.mjs
+++ b/scripts/check-docs-sync.mjs
@@ -30,12 +30,25 @@ const checks = [
         pattern: /output inside\s+Git metadata is refused/
       },
       {
-        label: 'local Action v2 candidate example',
+        label: 'local Action v2 prerelease example',
         pattern: /uses: \.\/action/
       },
       {
         label: 'Action v2 offline default',
         pattern: /stays offline unless\s+`external-links: 'true'`/
+      },
+      {
+        label: 'beta.3 source release',
+        pattern: /This source release is `2\.0\.0-beta\.3`/
+      }
+    ]
+  },
+  {
+    file: 'MIGRATION.md',
+    expectations: [
+      {
+        label: 'beta.3 migration boundary',
+        pattern: /`2\.0\.0-beta\.3` is an opt-in prerelease for npm's `next` tag/
       }
     ]
   },
@@ -128,12 +141,12 @@ const checks = [
     file: 'CHANGELOG.md',
     expectations: [
       {
-        label: 'unreleased beta.3 candidate entry',
-        pattern: /## \[Unreleased\] — 2\.0\.0-beta\.3 candidate/
+        label: 'beta.3 release entry',
+        pattern: /## \[2\.0\.0-beta\.3\] - 2026-08-11/
       },
       {
-        label: 'unpublished candidate boundary',
-        pattern: /describes source merged to `main`, not a published release/
+        label: 'prerelease channel boundary',
+        pattern: /this is an opt-in prerelease; `latest` remains on the stable v1 line/
       },
       {
         label: 'open private-beta gate',


### PR DESCRIPTION
## Summary
- bump the npm package to 2.0.0-beta.3
- align README, migration guide, changelog, and documentation tripwires
- keep npm latest on stable v1 and the supported Action on action@v1

## Verification
- npm test: 59/59, including 26/26 labeled checks with 0 blocking false positives
- npm run test:network
- isolated npm run test:performance
- npm run docs:sync-check
- npm --prefix action audit --omit=dev: 0 vulnerabilities
- npm pack --dry-run --json: 35 files
- installed the produced tarball in a temporary project; CLI reports beta.3 and scans its packed README
- real-codebase QA previously covered four authorized checkouts and 69 Markdown files with Git state unchanged
- git diff --check
- independent exact-diff review: GO

## Release boundary
- A4 still awaits qualifying real-user sessions; this prerelease does not claim stable adoption
- no npm publication, Git tag, GitHub Release, or Action v2 immutable reference is created by this PR
- npm publication must use --tag next; tag, prerelease, and final reference docs follow only after npm verification