### PR TITLE
docs: finalize 2.0.0-beta.3 release

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -64,11 +64,11 @@ jobs:
           DOCLIFY_COMPLETE: ${{ steps.action-smoke.outputs.complete }}
           DOCLIFY_BLOCKING: ${{ steps.action-smoke.outputs.blocking }}
         run: test "$DOCLIFY_STATUS" = pass && test "$DOCLIFY_COMPLETE" = true && test "$DOCLIFY_BLOCKING" = 0
-      # This full-SHA pin proves public installation of the frozen candidate;
+      # This full-SHA pin proves public installation of the beta.3 release;
       # the local ./action smoke above remains the coverage for current HEAD.
-      - name: Smoke frozen Action v2 candidate from an immutable reference
+      - name: Smoke released Action v2 beta.3 from an immutable reference
         id: action-sha-smoke
-        uses: Elgabor/doclify-guardrail/action@8b0ba3eda0462f9b1306a0b3eaf221337606a079
+        uses: Elgabor/doclify-guardrail/action@3e0f9970319c75ea1760f09e57b203d156144d26
         with:
           path: evidence/private-beta-protocol.md
       - name: Verify immutable Action reads the caller workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project are documented in this file.
 
 ### Notes
 
-- this is an opt-in prerelease; `latest` remains on the stable v1 line
+- `2.0.0-beta.3` is published on npm's `next` tag with a signed GitHub prerelease; `latest` remains on the stable v1 line
 - the performance tolerance catches macroscopic regressions; it is not evidence of a tight performance target
 - private-beta task A4 still awaits qualifying real-user sessions
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,7 +1,7 @@
 # Migrating to Doclify Guardrail v2
 
-`2.0.0-beta.3` is an opt-in prerelease for npm's `next` tag. `latest` remains
-on the v1 line. The v2 core is local and read-only by default.
+`2.0.0-beta.3` is published on npm's `next` tag. `latest` remains on the v1
+line. The v2 core is local and read-only by default.
 
 ## Command changes
 
@@ -77,7 +77,7 @@ silently accepted.
 | API `fix`, `score`, `RULE_CATALOG`, package-root import | Removed. |
 | config keys `strict`, `maxLineLength`, `checkLinks`, `checkFreshness`, `freshnessMaxDays`, `checkFrontmatter`, `checkInlineHtml`, `push`, `projectId` | Removed keys fail with `config-removed-key`. |
 | `.doclify-history.json`, `doclify-report.md`, `doclify-badge.svg`, `.doclify/` auth state | No v2 equivalent; remove them only after validating they are no longer used by your own workflow. |
-| Action inputs and outputs from `action@v1` | Stay on the frozen `Elgabor/doclify-guardrail/action@v1` contract, or migrate to the beta.3 contract below after an immutable v2 reference is published. |
+| Action inputs and outputs from `action@v1` | Stay on the frozen `Elgabor/doclify-guardrail/action@v1` contract, or test the beta.3 contract with the full release commit below. |
 
 MDX is classified as the limited `fragment` purpose unless configuration assigns
 another supported purpose. V2 does not evaluate MDX expressions.
@@ -91,8 +91,9 @@ claims. This is classification, not a style preset.
 `Elgabor/doclify-guardrail/action@v1` remains on its own v1 contract. This beta
 does not change, rebuild, or retag that Action.
 
-This source release contains the beta.3 Action adapter for local and
-immutable-checkout validation. It maps `mode`, `path`, `base`, `staged`,
+The beta.3 Action adapter is published under the signed tag
+`v2.0.0-beta.3` at commit `3e0f9970319c75ea1760f09e57b203d156144d26`.
+It maps `mode`, `path`, `base`, `staged`,
 `config`, `ignore-rules`, `exclude`, `site-root`, and the opt-in external-link
 settings directly to the v2 CLI. `mode: changed` requires exactly one of `base`
 or `staged`; base comparisons also require that revision in the checkout. It
@@ -102,7 +103,14 @@ calculate a score, or run Cloud and AI features. Its outputs are `status`,
 If the scan cannot start because the invocation or configuration is invalid,
 the step fails before those result outputs exist.
 
+```yaml
+- uses: Elgabor/doclify-guardrail/action@3e0f9970319c75ea1760f09e57b203d156144d26
+  with:
+    path: README.md
+```
+
 The v1 Action's SARIF and score outputs have no v2 Action equivalent. SARIF
 remains available from the CLI with `--format sarif --output <path>`. Do not
-replace `@v1` with a floating `@v2` reference until the separate v2 line has
-been published and smoke-tested; pin its immutable commit when available.
+replace `@v1` with a floating `@v2` reference. Test beta.3 with the full release
+commit above; its signed tag is
+`Elgabor/doclify-guardrail/action@v2.0.0-beta.3`.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Doclify Guardrail checks Markdown and MDX documentation against facts that are
 already present in the repository. It runs locally, does not execute documented
 commands, and does not contact the network unless `--external-links` is passed.
 
-This source release is `2.0.0-beta.3`, an opt-in prerelease for npm's `next`
-tag. `latest` remains on the stable v1 line. The supported v1 Action remains
-frozen at `Elgabor/doclify-guardrail/action@v1`.
+Version `2.0.0-beta.3` is published on npm's `next` tag. `latest` remains on
+the stable v1 line. The supported v1 Action remains frozen at
+`Elgabor/doclify-guardrail/action@v1`.
 
 ## Start
 
@@ -126,8 +126,8 @@ node ./src/index.mjs check examples/evidence-demo/fixtures/README.broken.md --co
 
 The beta.3 Action is a thin adapter over the same CLI result. It requires no
 token, has only `contents: read` permission, and stays offline unless
-`external-links: 'true'` is set. Until beta.3 has an immutable published
-reference, it can be verified from a checkout with the local Action path:
+`external-links: 'true'` is set. Its signed release tag is
+`v2.0.0-beta.3`. Pin the full release commit in CI:
 
 ```yaml
 permissions:
@@ -137,10 +137,13 @@ steps:
   - uses: actions/checkout@v5.0.1
     with:
       persist-credentials: false
-  - uses: ./action
+  - uses: Elgabor/doclify-guardrail/action@3e0f9970319c75ea1760f09e57b203d156144d26
     with:
       path: README.md
 ```
+
+The tag form is `Elgabor/doclify-guardrail/action@v2.0.0-beta.3`; the full SHA
+above prevents ref movement.
 
 Use `mode: changed` with exactly one of `base` or `staged: 'true'` to delegate
 Git selection to the v2 `changed` command. A base comparison needs the requested

--- a/evidence/portfolio-beta3-draft.md
+++ b/evidence/portfolio-beta3-draft.md
@@ -3,8 +3,9 @@
 Status: `DRAFT_DO_NOT_PUBLISH`
 
 This file prepares task A5. It does not authorize a portfolio edit or deploy.
-Publication remains blocked until the private beta evidence exists, beta.3 has
-an immutable released reference, and a separate portfolio task is authorized.
+Publication remains blocked until the private beta evidence exists and a
+separate portfolio task is authorized. Beta.3 now has a signed release tag and
+GitHub prerelease; that alone is not adoption evidence.
 
 ## Current claim audit
 
@@ -14,8 +15,9 @@ catalog. The replacement below names only behavior demonstrated by the public
 fixture and tests.
 
 As verified on 2026-08-11, npm serves `1.7.4` on `latest` and
-`2.0.0-beta.2` on `next`. The Action v2 adapter in this branch is a beta.3
-source candidate, not a published Action release.
+`2.0.0-beta.3` on `next`. The Action v2 adapter is published under the signed
+tag `v2.0.0-beta.3` at commit
+`3e0f9970319c75ea1760f09e57b203d156144d26`.
 
 ## Proposed Italian copy
 
@@ -43,7 +45,7 @@ source candidate, not a published Action release.
 | Offline by default | `README.md`, `scripts/check-network-boundary.mjs`, `test/action-v2.test.mjs`, and `.github/workflows/docs-check.yml` |
 | Does not execute documented examples | `README.md` and the static checker implementation |
 | Evidence for blocking errors | broken demo JSON output and the labeled correctness gate |
-| Open-source beta status | repository license and the immutable beta.3 release reference, once published |
+| Open-source beta status | repository license and the signed beta.3 release reference |
 
 The private beta may support a separate adoption statement only after A4 meets
 its declared thresholds. Do not add participant counts, time-to-result,
@@ -51,7 +53,8 @@ replacement claims, or quotations before that evidence is committed.
 
 ## Reproducible demo script
 
-Run from a clean checkout of the immutable beta.3 release reference.
+Run from a clean checkout of beta.3 commit
+`3e0f9970319c75ea1760f09e57b203d156144d26`.
 
 1. Show the clean local result:
 

--- a/scripts/check-docs-sync.mjs
+++ b/scripts/check-docs-sync.mjs
@@ -30,16 +30,16 @@ const checks = [
         pattern: /output inside\s+Git metadata is refused/
       },
       {
-        label: 'local Action v2 prerelease example',
-        pattern: /uses: \.\/action/
+        label: 'immutable Action v2 prerelease example',
+        pattern: /uses: Elgabor\/doclify-guardrail\/action@3e0f9970319c75ea1760f09e57b203d156144d26/
       },
       {
         label: 'Action v2 offline default',
         pattern: /stays offline unless\s+`external-links: 'true'`/
       },
       {
-        label: 'beta.3 source release',
-        pattern: /This source release is `2\.0\.0-beta\.3`/
+        label: 'beta.3 published release',
+        pattern: /Version `2\.0\.0-beta\.3` is published on npm's `next` tag/
       }
     ]
   },
@@ -48,7 +48,7 @@ const checks = [
     expectations: [
       {
         label: 'beta.3 migration boundary',
-        pattern: /`2\.0\.0-beta\.3` is an opt-in prerelease for npm's `next` tag/
+        pattern: /`2\.0\.0-beta\.3` is published on npm's `next` tag/
       }
     ]
   },
@@ -100,8 +100,8 @@ const checks = [
         pattern: /DOCLIFY_STATUS[\s\S]*?DOCLIFY_COMPLETE[\s\S]*?DOCLIFY_BLOCKING/
       },
       {
-        label: 'immutable Action candidate pin',
-        pattern: /uses: Elgabor\/doclify-guardrail\/action@8b0ba3eda0462f9b1306a0b3eaf221337606a079/
+        label: 'immutable Action release pin',
+        pattern: /uses: Elgabor\/doclify-guardrail\/action@3e0f9970319c75ea1760f09e57b203d156144d26/
       },
       {
         label: 'immutable Action caller-workspace proof',
@@ -138,6 +138,23 @@ const checks = [
     ]
   },
   {
+    file: 'evidence/portfolio-beta3-draft.md',
+    expectations: [
+      {
+        label: 'beta.3 registry evidence',
+        pattern: /npm serves `1\.7\.4` on `latest` and\s+`2\.0\.0-beta\.3` on `next`/
+      },
+      {
+        label: 'portfolio publication boundary',
+        pattern: /Publication remains blocked until the private beta evidence exists/
+      },
+      {
+        label: 'beta.3 release commit evidence',
+        pattern: /3e0f9970319c75ea1760f09e57b203d156144d26/
+      }
+    ]
+  },
+  {
     file: 'CHANGELOG.md',
     expectations: [
       {
@@ -146,7 +163,7 @@ const checks = [
       },
       {
         label: 'prerelease channel boundary',
-        pattern: /this is an opt-in prerelease; `latest` remains on the stable v1 line/
+        pattern: /`2\.0\.0-beta\.3` is published on npm's `next` tag with a signed GitHub prerelease; `latest` remains on the stable v1 line/
       },
       {
         label: 'open private-beta gate',


### PR DESCRIPTION
## Summary
- record the verified npm next publication and signed GitHub prerelease
- document the beta.3 Action release tag and immutable full-SHA pin
- replace the frozen candidate Action smoke with the published release commit
- keep A4 and portfolio publication explicitly open

## Verification
- npm test: 59/59
- labeled correctness: 26/26, 0 blocking false positives
- npm run docs:sync-check
- Action production audit: 0 vulnerabilities
- npm pack --dry-run --json: 35 files
- README, migration, changelog, and portfolio evidence scan: 4/4 pass
- npm next, gitHead, signed tag, and GitHub prerelease verified separately