### PR TITLE
docs(release): publish 2.0.0 release state

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -64,11 +64,11 @@ jobs:
           DOCLIFY_COMPLETE: ${{ steps.action-smoke.outputs.complete }}
           DOCLIFY_BLOCKING: ${{ steps.action-smoke.outputs.blocking }}
         run: test "$DOCLIFY_STATUS" = pass && test "$DOCLIFY_COMPLETE" = true && test "$DOCLIFY_BLOCKING" = 0
-      # This full-SHA pin proves public installation of the beta.3 release;
+      # This full-SHA pin proves public installation of the stable release;
       # the local ./action smoke above remains the coverage for current HEAD.
-      - name: Smoke released Action v2 beta.3 from an immutable reference
+      - name: Smoke released Action v2.0.0 from an immutable reference
         id: action-sha-smoke
-        uses: Elgabor/doclify-guardrail/action@3e0f9970319c75ea1760f09e57b203d156144d26
+        uses: Elgabor/doclify-guardrail/action@5ce78dcda488c3734b10ba2a5fdbf4b44fd20985
         with:
           path: evidence/private-beta-protocol.md
       - name: Verify immutable Action reads the caller workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
-## [2.0.0] - 2026-08-13
+## [2.0.0] - 2026-08-14
 
 ### Changed
 
 - removed residual v1-only helpers and centralized document-purpose policy without adding dependencies or compatibility paths
 - made indeterminate filesystem containment fail closed while preserving ordinary unreadable-file diagnostics
-- aligned the package and Action metadata, README, and migration guide for the stable candidate
+- aligned the package and Action metadata, README, and migration guide for the stable release
 
 ### Security
 
@@ -17,7 +17,7 @@ All notable changes to this project are documented in this file.
 
 ### Notes
 
-- this commit prepares the `2.0.0` candidate; npm `latest`, the stable GitHub Release, and the Action `v2` reference are not published by S3
+- `2.0.0` is published on npm's `latest` tag and in a GitHub Release backed by the signed `v2.0.0` tag; a floating Action `v2` reference has not been created
 - private-beta task A4 still awaits qualifying real-user sessions and is not inferred from repository QA
 
 ## [2.0.0-beta.3] - 2026-08-11

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,8 +1,7 @@
 # Migrating to Doclify Guardrail v2
 
-The repository candidate is `2.0.0`, but it is not published yet. npm still
-serves `2.0.0-beta.3` on `next` and the v1 line on `latest`. The v2 core is
-local and read-only by default.
+Version `2.0.0` is published on npm's `latest` tag. The v2 core is local and
+read-only by default.
 
 ## Command changes
 
@@ -78,7 +77,7 @@ silently accepted.
 | API `fix`, `score`, `RULE_CATALOG`, package-root import | Removed. |
 | config keys `strict`, `maxLineLength`, `checkLinks`, `checkFreshness`, `freshnessMaxDays`, `checkFrontmatter`, `checkInlineHtml`, `push`, `projectId` | Removed keys fail with `config-removed-key`. |
 | `.doclify-history.json`, `doclify-report.md`, `doclify-badge.svg`, `.doclify/` auth state | No v2 equivalent; remove them only after validating they are no longer used by your own workflow. |
-| Action inputs and outputs from `action@v1` | Stay on the frozen `Elgabor/doclify-guardrail/action@v1` contract, or test the beta.3 contract with the full release commit below. |
+| Action inputs and outputs from `action@v1` | Stay on the frozen `Elgabor/doclify-guardrail/action@v1` contract, or use the stable v2 contract with the full release commit below. |
 
 MDX is classified as the limited `fragment` purpose unless configuration assigns
 another supported purpose. V2 does not evaluate MDX expressions.
@@ -90,10 +89,10 @@ claims. This is classification, not a style preset.
 ## GitHub Action
 
 `Elgabor/doclify-guardrail/action@v1` remains on its own v1 contract. The v2
-candidate does not change or retag that Action.
+release does not change or retag that Action.
 
-The currently published v2 Action adapter is the beta.3 build under the signed tag
-`v2.0.0-beta.3` at commit `3e0f9970319c75ea1760f09e57b203d156144d26`.
+The stable v2 Action adapter is published under the signed tag `v2.0.0` at
+commit `5ce78dcda488c3734b10ba2a5fdbf4b44fd20985`.
 It maps `mode`, `path`, `base`, `staged`,
 `config`, `ignore-rules`, `exclude`, `site-root`, and the opt-in external-link
 settings directly to the v2 CLI. `mode: changed` requires exactly one of `base`
@@ -105,13 +104,13 @@ If the scan cannot start because the invocation or configuration is invalid,
 the step fails before those result outputs exist.
 
 ```yaml
-- uses: Elgabor/doclify-guardrail/action@3e0f9970319c75ea1760f09e57b203d156144d26
+- uses: Elgabor/doclify-guardrail/action@5ce78dcda488c3734b10ba2a5fdbf4b44fd20985
   with:
     path: README.md
 ```
 
 The v1 Action's SARIF and score outputs have no v2 Action equivalent. SARIF
 remains available from the CLI with `--format sarif --output <path>`. Do not
-replace `@v1` with a floating `@v2` reference before the stable Action is
-published. Test beta.3 with the full release commit above; its signed tag is
-`Elgabor/doclify-guardrail/action@v2.0.0-beta.3`.
+replace `@v1` with a floating `@v2` reference because that major reference has
+not been created. Use the full release commit above or the signed tag
+`Elgabor/doclify-guardrail/action@v2.0.0`.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,14 @@ Doclify Guardrail checks Markdown and MDX documentation against facts that are
 already present in the repository. It runs locally, does not execute documented
 commands, and does not contact the network unless `--external-links` is passed.
 
-The repository candidate is `2.0.0`, but the stable package and Action are not
-published yet. npm still serves `1.7.4` on `latest` and `2.0.0-beta.3` on
-`next`. The supported v1 Action remains frozen at
+Version `2.0.0` is published on npm's `latest` tag. The prerelease line remains
+at `2.0.0-beta.3` on `next`. The supported v1 Action remains frozen at
 `Elgabor/doclify-guardrail/action@v1`.
 
 ## Start
 
 ```sh
-npm install --save-dev doclify-guardrail@next
+npm install --save-dev doclify-guardrail
 npx doclify-guardrail check README.md
 ```
 
@@ -127,8 +126,7 @@ node ./src/index.mjs check examples/evidence-demo/fixtures/README.broken.md --co
 
 The v2 Action is a thin adapter over the same CLI result. It requires no token,
 has only `contents: read` permission, and stays offline unless
-`external-links: 'true'` is set. Until the stable Action is published, pin the
-published beta.3 release commit in CI:
+`external-links: 'true'` is set. Pin the stable release commit in CI:
 
 ```yaml
 permissions:
@@ -138,14 +136,13 @@ steps:
   - uses: actions/checkout@v5.0.1
     with:
       persist-credentials: false
-  - uses: Elgabor/doclify-guardrail/action@3e0f9970319c75ea1760f09e57b203d156144d26
+  - uses: Elgabor/doclify-guardrail/action@5ce78dcda488c3734b10ba2a5fdbf4b44fd20985
     with:
       path: README.md
 ```
 
-Its signed tag is `Elgabor/doclify-guardrail/action@v2.0.0-beta.3`; the full SHA
-above prevents ref movement. The stable `v2.0.0` tag and `v2` major reference
-remain publication steps, not artifacts created by this candidate.
+Its signed tag is `Elgabor/doclify-guardrail/action@v2.0.0`; the full SHA above
+prevents ref movement. A floating `v2` major reference has not been created.
 
 Use `mode: changed` with exactly one of `base` or `staged: 'true'` to delegate
 Git selection to the v2 `changed` command. A base comparison needs the requested

--- a/scripts/check-docs-sync.mjs
+++ b/scripts/check-docs-sync.mjs
@@ -30,16 +30,16 @@ const checks = [
         pattern: /output inside\s+Git metadata is refused/
       },
       {
-        label: 'immutable Action v2 prerelease example',
-        pattern: /uses: Elgabor\/doclify-guardrail\/action@3e0f9970319c75ea1760f09e57b203d156144d26/
+        label: 'immutable stable Action v2 example',
+        pattern: /uses: Elgabor\/doclify-guardrail\/action@5ce78dcda488c3734b10ba2a5fdbf4b44fd20985/
       },
       {
         label: 'Action v2 offline default',
         pattern: /stays offline unless\s+`external-links: 'true'`/
       },
       {
-        label: 'stable candidate publication boundary',
-        pattern: /The repository candidate is `2\.0\.0`, but the stable package and Action are not\s+published yet/
+        label: 'stable npm release',
+        pattern: /Version `2\.0\.0` is published on npm's `latest` tag/
       }
     ]
   },
@@ -47,8 +47,8 @@ const checks = [
     file: 'MIGRATION.md',
     expectations: [
       {
-        label: 'stable migration boundary',
-        pattern: /The repository candidate is `2\.0\.0`, but it is not published yet/
+        label: 'stable migration release',
+        pattern: /Version `2\.0\.0` is published on npm's `latest` tag/
       }
     ]
   },
@@ -119,7 +119,7 @@ const checks = [
       },
       {
         label: 'immutable Action release pin',
-        pattern: /uses: Elgabor\/doclify-guardrail\/action@3e0f9970319c75ea1760f09e57b203d156144d26/
+        pattern: /uses: Elgabor\/doclify-guardrail\/action@5ce78dcda488c3734b10ba2a5fdbf4b44fd20985/
       },
       {
         label: 'immutable Action caller-workspace proof',
@@ -175,6 +175,14 @@ const checks = [
   {
     file: 'CHANGELOG.md',
     expectations: [
+      {
+        label: 'stable release entry',
+        pattern: /## \[2\.0\.0\] - 2026-08-14/
+      },
+      {
+        label: 'stable release artifacts',
+        pattern: /`2\.0\.0` is published on npm's `latest` tag and in a GitHub Release backed by the signed `v2\.0\.0` tag/
+      },
       {
         label: 'beta.3 release entry',
         pattern: /## \[2\.0\.0-beta\.3\] - 2026-08-11/

--- a/tasks.md
+++ b/tasks.md
@@ -2,8 +2,7 @@
 
 Stato: registro operativo
 Piano di riferimento locale: `plan.md`
-Versioni pubblicate: stable `1.7.4`; prerelease `2.0.0-beta.3`; candidato locale
-`2.0.0` non pubblicato
+Versioni pubblicate: stable `2.0.0`; prerelease `2.0.0-beta.3`
 
 Questo file registra task, prove e rischi residui del prodotto. `plan.md` resta il piano
 locale di riferimento; codice, test e contratti pubblici restano le fonti di verità sul
@@ -734,27 +733,31 @@ Checklist candidata:
 - [x] versione, changelog, migrazione, README e metadati Action;
 - [x] bundle Action riproducibile e audit production senza vulnerabilità;
 - [x] pack, checksum, installazione offline e matrice completa finale;
-- [ ] merge della PR in `main`;
-- [ ] tag firmato `v2.0.0` e GitHub Release;
-- [ ] riferimento Action `v2` e pubblicazione npm su `latest`;
-- [ ] verifica indipendente degli artefatti pubblicati.
+- [x] merge della PR in `main`;
+- [x] tag firmato `v2.0.0` e GitHub Release;
+- [x] pubblicazione npm su `latest` e verifica indipendente dal registry;
+- [ ] riferimento mobile Action `v2`.
 
 ### S4 — Pubblicare e verificare 2.0.0
 
-Stato: `READY_FOR_RELEASE`
+Stato: `IN PROGRESS`
 
-Confine concordato per questo lavoro: creare e verificare branch, commit, push e PR
-verso `main`. Merge, tag, GitHub Release, spostamento Action `v2`, npm publish e
-portfolio restano esclusi. S4 non è `DONE` finché gli artefatti pubblicati non sono
-verificati separatamente.
+PR #31 è stata fusa in `main` come `5ce78dc`. I workflow post-merge Docs Check e
+Reliability sono verdi. npm pubblica `2.0.0` su `latest` con `gitHead=5ce78dc`,
+integrity `sha512-NSZYl2CbDA4TQfs30w2qqSuYD43rrLSyfjjUrMbEdN/gQwD9KHKdkIgEld6JtCcq6sg1ZsGABM8gfaVh6s31vg==`
+e shasum `2a594cf8c5ba2136e62d43e64d3b1b3524f4acd4`; `next` resta su
+`2.0.0-beta.3`. Installazione pulita, versione, help, check e API dal registry sono
+verdi.
 
-Stato pre-pubblicazione verificato il 2026-08-13: npm espone `latest=1.7.4` e
-`next=2.0.0-beta.3`; non esistono tag o GitHub Release `v2.0.0`.
+Il tag firmato `v2.0.0` punta a `5ce78dc` e la GitHub Release stabile è pubblicata:
+`https://github.com/Elgabor/doclify-guardrail/releases/tag/v2.0.0`. Il riferimento
+immutabile Action `v2.0.0` è disponibile; resta da decidere e creare il major mobile
+`v2`. A4 resta `BLOCKED_INPUT` e il portfolio richiede una task separata.
 
-PR #31 aperta da `release/v2.0.0` verso `main`. Sul head `20f30a7`, gli otto check
-GitHub di push e pull request (`guardrail`, `correctness`, `network`, `performance`)
-sono verdi. La commit che registra questa evidenza deve superare nuovamente gli stessi
-gate prima della consegna.
+Rischio residuo: il tarball npm `2.0.0` è immutabile e contiene i documenti del
+candidato, antecedenti a questa correzione post-release. GitHub e il repository
+vengono allineati con una PR protetta; correggere anche i documenti inclusi nel
+pacchetto richiede una nuova versione e non è autorizzato da questa task.
 
 Azioni, ciascuna soggetta all'autorizzazione ricevuta:
 
@@ -952,7 +955,7 @@ Compilare una riga dopo ogni task completata:
 | P4 | DONE | `369dd45` | test contratto beta.2; docs sync; demo stdin/output/explain | Output testuale limitato; formati macchina completi e deterministici. |
 | P5 | DONE | `369dd45` | esempi clean/failing; docs sync; scan v2; pack dry-run; demo riproducibile | README e migrazione dichiarano beta.2; Action v2 resta futura. |
 | A1 | DONE | `7d5188c` | suite 59/59; pack installato; QA 69 file su 4 checkout autorizzati; Git invariato | Output Markdown non sovrascrivibile; report non Markdown atomici; invocazione bin npm via symlink coperta. |
-| A2 | DONE | `df0ad54` | test Action sorgente/bundle; build riproducibile; audit 0 vulnerabilità; smoke locale e SHA immutabile in CI | Nel gate beta.3 l'Action package era `1.7.4`; S3 allinea il candidato a `2.0.0`. `v2.0.0-beta.3` resta il riferimento immutabile pubblicato e non esiste ancora un alias mobile `v2`. |
+| A2 | DONE | `df0ad54` | test Action sorgente/bundle; build riproducibile; audit 0 vulnerabilità; smoke locale e SHA immutabile in CI | L'Action stabile è disponibile con tag `v2.0.0` e SHA `5ce78dc`; non esiste ancora un alias mobile `v2`. |
 | A3 | DONE | `c71434e`, `2170e26` | 26/26 casi etichettati; 0 falsi positivi bloccanti; rete locale; property test; perf Linux/macOS verde | Soglia CI ampia, adatta solo a regressioni macroscopiche; test symlink saltati solo su Windows; evidenza reale demandata ad A4. |
 | A4 | BLOCKED_INPUT | `2048e4c` | protocollo e confini privacy revisionati; nessun risultato qualificante registrato | Richiede 3-5 utenti reali, almeno 3 completamenti e 30 finding revisionati; non inferire adozione dalla QA locale. |
 | A5 | DONE | `e21ba8e`, `7e74c42` | demo su tarball/checkouts puliti; claim mappati a prove pubbliche; changelog candidato; review anti-slop | Solo draft; portfolio intatto e pubblicazione non autorizzata. |
@@ -961,7 +964,7 @@ Compilare una riga dopo ogni task completata:
 | S1.2 | DONE | `1de75ae` | fail pre-fix; Node/Docker regression; rete; suite 64/64; confini IANA pubblici/non globali | Registry IANA può evolvere; aggiornare solo da fonte primaria e con test di confine. |
 | S2 | DONE | `f22486f`, `1de75ae`, `7acd109` | 64/64; 41/41; rete/performance/docs/pack; DwarfStar/Redis tutte le superfici; mutazioni 5/5; pack installato; Action audit 0 | A4 resta senza prove real-user; classe performance Docker ARM non registrata. |
 | S3 | DONE | `7acd109` | metadata/docs; bundle; pack 35 file; SHA-256; install offline; CLI/API sui due corpus | Candidato soltanto: registry, tag, Release e Action stable non pubblicati. |
-| S4 | READY_FOR_RELEASE | PR #31 | stato npm/tag/Release verificato; checklist pronta; 8 check GitHub verdi su `20f30a7` | Confine corrente termina alla PR; pubblicazione e verifica esterna restano da eseguire. |
+| S4 | IN PROGRESS | PR #31, `5ce78dc`, `v2.0.0` | merge e CI; npm `latest`; install smoke; tag firmato; GitHub Release; Action SHA/tag immutabili | Restano il major mobile Action `v2`, la task portfolio e l'eventuale versione documentale successiva; A4 resta `BLOCKED_INPUT`. |
 | R1 | TODO | - | - | - |
 | R2-R5 | BLOCKED | - | - | R1 deve produrre go |
 | E1-E4 | BLOCKED | - | - | domanda reale non ancora dimostrata |


### PR DESCRIPTION
## Why

The npm package and GitHub Release are now published, while the repository documentation still describes a release candidate.

## Changes

- document npm `latest=2.0.0` and the signed `v2.0.0` tag
- pin the stable Action release commit in README, migration guidance, and CI smoke coverage
- update the changelog, docs synchronization assertions, and S4 evidence in `tasks.md`

## Verification

- `npm test` — 64/64 tests and 41/41 labeled cases
- `npm run docs:sync-check`
- Doclify scan of README, migration guide, changelog, and tasks — 4/4 pass
- CLI version, example, stdin JSON, pack dry-run, and `git diff --check`
- commit signature verified locally

## Boundaries

- no floating Action `v2` reference was created
- no new npm version was published
- the immutable npm 2.0.0 tarball still contains its candidate-era docs; correcting that artifact requires a later version
- A4 real-user evidence and the portfolio remain separate work