### PR TITLE
chore(release): prepare doclify guardrail 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project are documented in this file.
 
+## [2.0.1] - 2026-08-14
+
+### Changed
+
+- corrected the packaged README and migration guide to describe the stable npm and GitHub Action releases
+- aligned the npm package and Action metadata with the patch version
+
+### Notes
+
+- the signed `v2.0.1` tag identifies this release; the movable Action tag `v2` follows the latest compatible v2 release
+- private-beta task A4 still awaits qualifying real-user sessions and is not inferred from repository QA
+
 ## [2.0.0] - 2026-08-14
 
 ### Changed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migrating to Doclify Guardrail v2
 
-Version `2.0.0` is published on npm's `latest` tag. The v2 core is local and
+Version `2.0.1` is the current stable npm release. The v2 core is local and
 read-only by default.
 
 ## Command changes
@@ -91,8 +91,7 @@ claims. This is classification, not a style preset.
 `Elgabor/doclify-guardrail/action@v1` remains on its own v1 contract. The v2
 release does not change or retag that Action.
 
-The stable v2 Action adapter is published under the signed tag `v2.0.0` at
-commit `5ce78dcda488c3734b10ba2a5fdbf4b44fd20985`.
+The stable v2 Action adapter is published under the signed tag `v2.0.1`.
 It maps `mode`, `path`, `base`, `staged`,
 `config`, `ignore-rules`, `exclude`, `site-root`, and the opt-in external-link
 settings directly to the v2 CLI. `mode: changed` requires exactly one of `base`
@@ -104,13 +103,13 @@ If the scan cannot start because the invocation or configuration is invalid,
 the step fails before those result outputs exist.
 
 ```yaml
-- uses: Elgabor/doclify-guardrail/action@5ce78dcda488c3734b10ba2a5fdbf4b44fd20985
+- uses: Elgabor/doclify-guardrail/action@v2.0.1
   with:
     path: README.md
 ```
 
 The v1 Action's SARIF and score outputs have no v2 Action equivalent. SARIF
-remains available from the CLI with `--format sarif --output <path>`. Do not
-replace `@v1` with a floating `@v2` reference because that major reference has
-not been created. Use the full release commit above or the signed tag
-`Elgabor/doclify-guardrail/action@v2.0.0`.
+remains available from the CLI with `--format sarif --output <path>`. Use
+`Elgabor/doclify-guardrail/action@v2` for compatible v2 updates, the signed
+`v2.0.1` tag for the specific release, or its full commit SHA for an immutable
+reference.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Doclify Guardrail checks Markdown and MDX documentation against facts that are
 already present in the repository. It runs locally, does not execute documented
 commands, and does not contact the network unless `--external-links` is passed.
 
-Version `2.0.0` is published on npm's `latest` tag. The prerelease line remains
+Version `2.0.1` is the current stable npm release. The prerelease line remains
 at `2.0.0-beta.3` on `next`. The supported v1 Action remains frozen at
 `Elgabor/doclify-guardrail/action@v1`.
 
@@ -126,7 +126,7 @@ node ./src/index.mjs check examples/evidence-demo/fixtures/README.broken.md --co
 
 The v2 Action is a thin adapter over the same CLI result. It requires no token,
 has only `contents: read` permission, and stays offline unless
-`external-links: 'true'` is set. Pin the stable release commit in CI:
+`external-links: 'true'` is set. Pin the release-specific tag in CI:
 
 ```yaml
 permissions:
@@ -136,13 +136,14 @@ steps:
   - uses: actions/checkout@v5.0.1
     with:
       persist-credentials: false
-  - uses: Elgabor/doclify-guardrail/action@5ce78dcda488c3734b10ba2a5fdbf4b44fd20985
+  - uses: Elgabor/doclify-guardrail/action@v2.0.1
     with:
       path: README.md
 ```
 
-Its signed tag is `Elgabor/doclify-guardrail/action@v2.0.0`; the full SHA above
-prevents ref movement. A floating `v2` major reference has not been created.
+The release tag `v2.0.1` is signed. Use `Elgabor/doclify-guardrail/action@v2`
+to follow the latest compatible v2 release, or pin the full commit SHA from the
+release page when the workflow requires an immutable reference.
 
 Use `mode: changed` with exactly one of `base` or `staged: 'true'` to delegate
 Git selection to the v2 `changed` command. A base comparison needs the requested

--- a/action/package-lock.json
+++ b/action/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doclify-guardrail-action",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doclify-guardrail-action",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@actions/core": "^3.0.1"
       },

--- a/action/package.json
+++ b/action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doclify-guardrail-action",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doclify-guardrail",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "Deterministic, local, read-only documentation integrity checks for Markdown repositories.",
   "homepage": "https://github.com/Elgabor/doclify-guardrail#readme",

--- a/scripts/check-docs-sync.mjs
+++ b/scripts/check-docs-sync.mjs
@@ -30,8 +30,8 @@ const checks = [
         pattern: /output inside\s+Git metadata is refused/
       },
       {
-        label: 'immutable stable Action v2 example',
-        pattern: /uses: Elgabor\/doclify-guardrail\/action@5ce78dcda488c3734b10ba2a5fdbf4b44fd20985/
+        label: 'release-specific Action v2 example',
+        pattern: /uses: Elgabor\/doclify-guardrail\/action@v2\.0\.1/
       },
       {
         label: 'Action v2 offline default',
@@ -39,7 +39,7 @@ const checks = [
       },
       {
         label: 'stable npm release',
-        pattern: /Version `2\.0\.0` is published on npm's `latest` tag/
+        pattern: /Version `2\.0\.1` is the current stable npm release/
       }
     ]
   },
@@ -48,7 +48,7 @@ const checks = [
     expectations: [
       {
         label: 'stable migration release',
-        pattern: /Version `2\.0\.0` is published on npm's `latest` tag/
+        pattern: /Version `2\.0\.1` is the current stable npm release/
       }
     ]
   },
@@ -57,7 +57,7 @@ const checks = [
     expectations: [
       {
         label: 'stable package version',
-        pattern: /"version": "2\.0\.0"/
+        pattern: /"version": "2\.0\.1"/
       }
     ]
   },
@@ -66,7 +66,7 @@ const checks = [
     expectations: [
       {
         label: 'stable Action package version',
-        pattern: /"version": "2\.0\.0"/
+        pattern: /"version": "2\.0\.1"/
       }
     ]
   },
@@ -175,6 +175,14 @@ const checks = [
   {
     file: 'CHANGELOG.md',
     expectations: [
+      {
+        label: 'patch release entry',
+        pattern: /## \[2\.0\.1\] - 2026-08-14/
+      },
+      {
+        label: 'Action major release policy',
+        pattern: /the movable Action tag `v2` follows the latest compatible v2 release/
+      },
       {
         label: 'stable release entry',
         pattern: /## \[2\.0\.0\] - 2026-08-14/

--- a/tasks.md
+++ b/tasks.md
@@ -2,7 +2,8 @@
 
 Stato: registro operativo
 Piano di riferimento locale: `plan.md`
-Versioni pubblicate: stable `2.0.0`; prerelease `2.0.0-beta.3`
+Versioni pubblicate: stable `2.0.0`; prerelease `2.0.0-beta.3`; patch `2.0.1`
+in preparazione
 
 Questo file registra task, prove e rischi residui del prodotto. `plan.md` resta il piano
 locale di riferimento; codice, test e contratti pubblici restano le fonti di verità sul
@@ -754,10 +755,27 @@ Il tag firmato `v2.0.0` punta a `5ce78dc` e la GitHub Release stabile è pubblic
 immutabile Action `v2.0.0` è disponibile; resta da decidere e creare il major mobile
 `v2`. A4 resta `BLOCKED_INPUT` e il portfolio richiede una task separata.
 
-Rischio residuo: il tarball npm `2.0.0` è immutabile e contiene i documenti del
-candidato, antecedenti a questa correzione post-release. GitHub e il repository
-vengono allineati con una PR protetta; correggere anche i documenti inclusi nel
-pacchetto richiede una nuova versione e non è autorizzato da questa task.
+Il tarball npm `2.0.0` è immutabile e contiene i documenti del candidato,
+antecedenti alla correzione post-release. La patch `2.0.1` è autorizzata per
+includere README e migrazione aggiornati; il tag mobile Action `v2` deve puntare
+allo stesso commit della patch senza modificare `v1`.
+
+Preparazione `2.0.1`: suite 64/64, corpus etichettato 41/41, rete, performance,
+docs sync, scansione dei documenti, bundle Action e audit production sono verdi.
+Il tarball contiene 35 file, ha npm shasum
+`fce4fd6255477652fd60c406514498e02c19e9dc` e SHA-256
+`de9f367d23f3ae7a37b76d196787b33ca167723e8725c8e9e7ed31960503390d`.
+Installazione, CLI e API sono verdi localmente; il pack/install Node 22 Docker è
+verde in modalità offline, read-only e non-root. Il runtime non è cambiato, quindi
+la matrice DwarfStar/Redis già registrata per `2.0.0` non è stata riclonata.
+
+Checklist di chiusura `2.0.1`:
+
+- [ ] merge protetto del diff di release;
+- [ ] tag firmato e GitHub Release `v2.0.1`;
+- [ ] pubblicazione npm `2.0.1` su `latest` e installazione pulita;
+- [ ] creazione del riferimento mobile Action `v2` sul commit `v2.0.1`;
+- [ ] PR finale con SHA e prove degli artefatti pubblicati.
 
 Azioni, ciascuna soggetta all'autorizzazione ricevuta:
 
@@ -964,7 +982,7 @@ Compilare una riga dopo ogni task completata:
 | S1.2 | DONE | `1de75ae` | fail pre-fix; Node/Docker regression; rete; suite 64/64; confini IANA pubblici/non globali | Registry IANA può evolvere; aggiornare solo da fonte primaria e con test di confine. |
 | S2 | DONE | `f22486f`, `1de75ae`, `7acd109` | 64/64; 41/41; rete/performance/docs/pack; DwarfStar/Redis tutte le superfici; mutazioni 5/5; pack installato; Action audit 0 | A4 resta senza prove real-user; classe performance Docker ARM non registrata. |
 | S3 | DONE | `7acd109` | metadata/docs; bundle; pack 35 file; SHA-256; install offline; CLI/API sui due corpus | Candidato soltanto: registry, tag, Release e Action stable non pubblicati. |
-| S4 | IN PROGRESS | PR #31, `5ce78dc`, `v2.0.0` | merge e CI; npm `latest`; install smoke; tag firmato; GitHub Release; Action SHA/tag immutabili | Restano il major mobile Action `v2`, la task portfolio e l'eventuale versione documentale successiva; A4 resta `BLOCKED_INPUT`. |
+| S4 | IN PROGRESS | PR #31, `5ce78dc`, `v2.0.0` | merge e CI; npm `latest`; install smoke; tag firmato; GitHub Release; Action SHA/tag immutabili | Patch `2.0.1` e major mobile Action `v2` autorizzati; A4 resta `BLOCKED_INPUT`. |
 | R1 | TODO | - | - | - |
 | R2-R5 | BLOCKED | - | - | R1 deve produrre go |
 | E1-E4 | BLOCKED | - | - | domanda reale non ancora dimostrata |


### PR DESCRIPTION
## Perché

The immutable 2.0.0 npm tarball contains candidate-era README and migration text. This patch publishes the corrected package documentation and introduces the supported Action v2 major tag without changing runtime behavior.

## Cosa cambia

- bump npm and Action metadata to 2.0.1
- package stable npm and Action v2.0.1/v2 instructions
- add the 2.0.1 changelog entry and release checklist
- update documentation synchronization assertions

## Come verificare

- `npm test` — 64/64 tests; 41/41 labeled cases
- network, performance, docs sync, four-document scan and diff check
- Action bundle parity and production audit — 0 vulnerabilities
- 35-file tarball installed and exercised through CLI/API
- Node 22 Docker pack/install smoke, offline, read-only and non-root

## Rischi e rollback

No runtime source or Action bundle changed. The exact release SHA and published registry evidence will be recorded in a post-release PR because they do not exist before this protected merge. The v1 Action tag remains untouched. A4 remains BLOCKED_INPUT.