### PR TITLE
docs(release): record 2.0.1 publication

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -66,9 +66,9 @@ jobs:
         run: test "$DOCLIFY_STATUS" = pass && test "$DOCLIFY_COMPLETE" = true && test "$DOCLIFY_BLOCKING" = 0
       # This full-SHA pin proves public installation of the stable release;
       # the local ./action smoke above remains the coverage for current HEAD.
-      - name: Smoke released Action v2.0.0 from an immutable reference
+      - name: Smoke released Action v2.0.1 from an immutable reference
         id: action-sha-smoke
-        uses: Elgabor/doclify-guardrail/action@5ce78dcda488c3734b10ba2a5fdbf4b44fd20985
+        uses: Elgabor/doclify-guardrail/action@ad98fb4efc0744360c305747767070d0549c764f
         with:
           path: evidence/private-beta-protocol.md
       - name: Verify immutable Action reads the caller workspace
@@ -77,6 +77,18 @@ jobs:
           DOCLIFY_COMPLETE: ${{ steps.action-sha-smoke.outputs.complete }}
           DOCLIFY_FILES: ${{ steps.action-sha-smoke.outputs.files }}
           DOCLIFY_BLOCKING: ${{ steps.action-sha-smoke.outputs.blocking }}
+        run: test "$DOCLIFY_STATUS" = pass && test "$DOCLIFY_COMPLETE" = true && test "$DOCLIFY_FILES" = 1 && test "$DOCLIFY_BLOCKING" = 0
+      - name: Smoke Action v2 major reference
+        id: action-major-smoke
+        uses: Elgabor/doclify-guardrail/action@v2
+        with:
+          path: evidence/private-beta-protocol.md
+      - name: Verify Action v2 major reference
+        env:
+          DOCLIFY_STATUS: ${{ steps.action-major-smoke.outputs.status }}
+          DOCLIFY_COMPLETE: ${{ steps.action-major-smoke.outputs.complete }}
+          DOCLIFY_FILES: ${{ steps.action-major-smoke.outputs.files }}
+          DOCLIFY_BLOCKING: ${{ steps.action-major-smoke.outputs.blocking }}
         run: test "$DOCLIFY_STATUS" = pass && test "$DOCLIFY_COMPLETE" = true && test "$DOCLIFY_FILES" = 1 && test "$DOCLIFY_BLOCKING" = 0
       - name: Audit action dependency chain
         working-directory: action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project are documented in this file.
 
 ### Notes
 
-- the signed `v2.0.1` tag identifies this release; the movable Action tag `v2` follows the latest compatible v2 release
+- `2.0.1` is published on npm's `latest` tag and in a GitHub Release backed by the signed `v2.0.1` tag; the movable Action tag `v2` points to the same commit
 - private-beta task A4 still awaits qualifying real-user sessions and is not inferred from repository QA
 
 ## [2.0.0] - 2026-08-14

--- a/scripts/check-docs-sync.mjs
+++ b/scripts/check-docs-sync.mjs
@@ -119,11 +119,15 @@ const checks = [
       },
       {
         label: 'immutable Action release pin',
-        pattern: /uses: Elgabor\/doclify-guardrail\/action@5ce78dcda488c3734b10ba2a5fdbf4b44fd20985/
+        pattern: /uses: Elgabor\/doclify-guardrail\/action@ad98fb4efc0744360c305747767070d0549c764f/
       },
       {
         label: 'immutable Action caller-workspace proof',
         pattern: /path: evidence\/private-beta-protocol\.md[\s\S]*?DOCLIFY_FILES/
+      },
+      {
+        label: 'Action v2 major reference smoke',
+        pattern: /uses: Elgabor\/doclify-guardrail\/action@v2\s/
       },
       {
         label: 'docs sync step',
@@ -181,7 +185,7 @@ const checks = [
       },
       {
         label: 'Action major release policy',
-        pattern: /the movable Action tag `v2` follows the latest compatible v2 release/
+        pattern: /`2\.0\.1` is published on npm's `latest` tag and in a GitHub Release[\s\S]*?Action tag `v2` points to the same commit/
       },
       {
         label: 'stable release entry',

--- a/tasks.md
+++ b/tasks.md
@@ -2,8 +2,7 @@
 
 Stato: registro operativo
 Piano di riferimento locale: `plan.md`
-Versioni pubblicate: stable `2.0.0`; prerelease `2.0.0-beta.3`; patch `2.0.1`
-in preparazione
+Versioni pubblicate: stable `2.0.1`; prerelease `2.0.0-beta.3`
 
 Questo file registra task, prove e rischi residui del prodotto. `plan.md` resta il piano
 locale di riferimento; codice, test e contratti pubblici restano le fonti di verità sul
@@ -737,28 +736,23 @@ Checklist candidata:
 - [x] merge della PR in `main`;
 - [x] tag firmato `v2.0.0` e GitHub Release;
 - [x] pubblicazione npm su `latest` e verifica indipendente dal registry;
-- [ ] riferimento mobile Action `v2`.
+- [x] riferimento mobile Action `v2`.
 
-### S4 — Pubblicare e verificare 2.0.0
+### S4 — Pubblicare e verificare 2.0.x
 
-Stato: `IN PROGRESS`
+Stato: `VERIFYING`
 
-PR #31 è stata fusa in `main` come `5ce78dc`. I workflow post-merge Docs Check e
-Reliability sono verdi. npm pubblica `2.0.0` su `latest` con `gitHead=5ce78dc`,
-integrity `sha512-NSZYl2CbDA4TQfs30w2qqSuYD43rrLSyfjjUrMbEdN/gQwD9KHKdkIgEld6JtCcq6sg1ZsGABM8gfaVh6s31vg==`
-e shasum `2a594cf8c5ba2136e62d43e64d3b1b3524f4acd4`; `next` resta su
-`2.0.0-beta.3`. Installazione pulita, versione, help, check e API dal registry sono
-verdi.
+La PR #33 è stata fusa in `main` come `ad98fb4`; Docs Check e Reliability sono
+verdi. npm pubblica `2.0.1` su `latest` con `gitHead=ad98fb4`, integrity
+`sha512-NMI7TqTlXk7K0gtoUi5J/7fPu+L4t5ePHGJ+QG3g7AKKimTAx5OweTs5padhTA/djLSHTRWAdcmGIntBQCFoyA==`
+e shasum `fce4fd6255477652fd60c406514498e02c19e9dc`; `next` resta su
+`2.0.0-beta.3`.
 
-Il tag firmato `v2.0.0` punta a `5ce78dc` e la GitHub Release stabile è pubblicata:
-`https://github.com/Elgabor/doclify-guardrail/releases/tag/v2.0.0`. Il riferimento
-immutabile Action `v2.0.0` è disponibile; resta da decidere e creare il major mobile
-`v2`. A4 resta `BLOCKED_INPUT` e il portfolio richiede una task separata.
-
-Il tarball npm `2.0.0` è immutabile e contiene i documenti del candidato,
-antecedenti alla correzione post-release. La patch `2.0.1` è autorizzata per
-includere README e migrazione aggiornati; il tag mobile Action `v2` deve puntare
-allo stesso commit della patch senza modificare `v1`.
+Il tag firmato `v2.0.1`, la GitHub Release
+`https://github.com/Elgabor/doclify-guardrail/releases/tag/v2.0.1` e il tag mobile
+firmato `v2` puntano tutti ad `ad98fb4`. `v1` resta su `78a59f7`. Il tarball
+`2.0.1` sostituisce la documentazione candidata rimasta nel tarball immutabile
+`2.0.0`.
 
 Preparazione `2.0.1`: suite 64/64, corpus etichettato 41/41, rete, performance,
 docs sync, scansione dei documenti, bundle Action e audit production sono verdi.
@@ -771,17 +765,17 @@ la matrice DwarfStar/Redis già registrata per `2.0.0` non è stata riclonata.
 
 Checklist di chiusura `2.0.1`:
 
-- [ ] merge protetto del diff di release;
-- [ ] tag firmato e GitHub Release `v2.0.1`;
-- [ ] pubblicazione npm `2.0.1` su `latest` e installazione pulita;
-- [ ] creazione del riferimento mobile Action `v2` sul commit `v2.0.1`;
+- [x] merge protetto del diff di release;
+- [x] tag firmato e GitHub Release `v2.0.1`;
+- [x] pubblicazione npm `2.0.1` su `latest` e installazione pulita;
+- [x] creazione del riferimento mobile Action `v2` sul commit `v2.0.1`;
 - [ ] PR finale con SHA e prove degli artefatti pubblicati.
 
 Azioni, ciascuna soggetta all'autorizzazione ricevuta:
 
 1. merge del branch di release in `main`;
 2. push di branch e `main` su `origin`;
-3. creazione e push del tag immutabile `v2.0.0`;
+3. creazione e push del tag immutabile `v2.0.1`;
 4. GitHub Release;
 5. aggiornamento linea Action `v2` senza spostare `v1`;
 6. `npm publish --tag latest`;
@@ -982,7 +976,7 @@ Compilare una riga dopo ogni task completata:
 | S1.2 | DONE | `1de75ae` | fail pre-fix; Node/Docker regression; rete; suite 64/64; confini IANA pubblici/non globali | Registry IANA può evolvere; aggiornare solo da fonte primaria e con test di confine. |
 | S2 | DONE | `f22486f`, `1de75ae`, `7acd109` | 64/64; 41/41; rete/performance/docs/pack; DwarfStar/Redis tutte le superfici; mutazioni 5/5; pack installato; Action audit 0 | A4 resta senza prove real-user; classe performance Docker ARM non registrata. |
 | S3 | DONE | `7acd109` | metadata/docs; bundle; pack 35 file; SHA-256; install offline; CLI/API sui due corpus | Candidato soltanto: registry, tag, Release e Action stable non pubblicati. |
-| S4 | IN PROGRESS | PR #31, `5ce78dc`, `v2.0.0` | merge e CI; npm `latest`; install smoke; tag firmato; GitHub Release; Action SHA/tag immutabili | Patch `2.0.1` e major mobile Action `v2` autorizzati; A4 resta `BLOCKED_INPUT`. |
+| S4 | VERIFYING | PR #31, PR #33, `ad98fb4`, `v2.0.1`, `v2` | merge e CI; npm `latest`; install smoke; tag firmati; GitHub Release; Action SHA/tag mobile | Manca il gate della PR finale di evidenza; A4 resta `BLOCKED_INPUT`. |
 | R1 | TODO | - | - | - |
 | R2-R5 | BLOCKED | - | - | R1 deve produrre go |
 | E1-E4 | BLOCKED | - | - | domanda reale non ancora dimostrata |

--- a/tasks.md
+++ b/tasks.md
@@ -740,7 +740,7 @@ Checklist candidata:
 
 ### S4 — Pubblicare e verificare 2.0.x
 
-Stato: `VERIFYING`
+Stato: `DONE`
 
 La PR #33 è stata fusa in `main` come `ad98fb4`; Docs Check e Reliability sono
 verdi. npm pubblica `2.0.1` su `latest` con `gitHead=ad98fb4`, integrity
@@ -752,7 +752,8 @@ Il tag firmato `v2.0.1`, la GitHub Release
 `https://github.com/Elgabor/doclify-guardrail/releases/tag/v2.0.1` e il tag mobile
 firmato `v2` puntano tutti ad `ad98fb4`. `v1` resta su `78a59f7`. Il tarball
 `2.0.1` sostituisce la documentazione candidata rimasta nel tarball immutabile
-`2.0.0`.
+`2.0.0`. La PR #34 prova in CI sia lo SHA completo sia `action@v2`; entrambi gli
+smoke sono verdi.
 
 Preparazione `2.0.1`: suite 64/64, corpus etichettato 41/41, rete, performance,
 docs sync, scansione dei documenti, bundle Action e audit production sono verdi.
@@ -769,7 +770,7 @@ Checklist di chiusura `2.0.1`:
 - [x] tag firmato e GitHub Release `v2.0.1`;
 - [x] pubblicazione npm `2.0.1` su `latest` e installazione pulita;
 - [x] creazione del riferimento mobile Action `v2` sul commit `v2.0.1`;
-- [ ] PR finale con SHA e prove degli artefatti pubblicati.
+- [x] PR finale con SHA e prove degli artefatti pubblicati.
 
 Azioni, ciascuna soggetta all'autorizzazione ricevuta:
 
@@ -976,7 +977,7 @@ Compilare una riga dopo ogni task completata:
 | S1.2 | DONE | `1de75ae` | fail pre-fix; Node/Docker regression; rete; suite 64/64; confini IANA pubblici/non globali | Registry IANA può evolvere; aggiornare solo da fonte primaria e con test di confine. |
 | S2 | DONE | `f22486f`, `1de75ae`, `7acd109` | 64/64; 41/41; rete/performance/docs/pack; DwarfStar/Redis tutte le superfici; mutazioni 5/5; pack installato; Action audit 0 | A4 resta senza prove real-user; classe performance Docker ARM non registrata. |
 | S3 | DONE | `7acd109` | metadata/docs; bundle; pack 35 file; SHA-256; install offline; CLI/API sui due corpus | Candidato soltanto: registry, tag, Release e Action stable non pubblicati. |
-| S4 | VERIFYING | PR #31, PR #33, `ad98fb4`, `v2.0.1`, `v2` | merge e CI; npm `latest`; install smoke; tag firmati; GitHub Release; Action SHA/tag mobile | Manca il gate della PR finale di evidenza; A4 resta `BLOCKED_INPUT`. |
+| S4 | DONE | PR #31, PR #33, PR #34, `ad98fb4`, `v2.0.1`, `v2` | merge e CI; npm `latest`; install smoke; tag firmati; GitHub Release; Action SHA e `v2` provate in CI | A4 resta `BLOCKED_INPUT`; il portfolio resta una task separata. |
 | R1 | TODO | - | - | - |
 | R2-R5 | BLOCKED | - | - | R1 deve produrre go |
 | E1-E4 | BLOCKED | - | - | domanda reale non ancora dimostrata |


### PR DESCRIPTION
## Perché

Record the independently verified 2.0.1 artifacts and close the protected release workflow.

## Cosa cambia

- pin the public Action smoke to the 2.0.1 release SHA
- execute the moving `action@v2` reference in CI and verify its outputs
- record npm, GitHub Release, signed tags and checksums
- move S4 to its final verification gate

## Come verificare

- `npm run docs:sync-check`
- Doclify scan of changelog and tasks
- `git diff --check`
- required CI, including both the immutable SHA and `@v2` Action smokes

## Limiti

No runtime, package contents, Action source or Action bundle changed. A4 remains BLOCKED_INPUT and the portfolio remains separate.